### PR TITLE
Single source of truth for selected call

### DIFF
--- a/src/actions/call.js
+++ b/src/actions/call.js
@@ -1,6 +1,6 @@
 import * as types from '.';
 
-import { currentCall, reportForCall } from '../store/calls';
+import { currentCall, reportForCallById } from '../store/calls';
 import { assignmentById } from '../store/assignments';
 
 
@@ -76,37 +76,38 @@ export function deallocateCall(call) {
     };
 }
 
-export function setCallReportField(field, value) {
+export function setCallReportField(call, field, value) {
     return {
         type: types.SET_CALL_REPORT_FIELD,
-        payload: { field, value },
+        payload: { call, field, value },
     };
 }
 
-export function setCallReportStep(step) {
+export function setCallReportStep(call, step) {
     return {
         type: types.SET_CALL_REPORT_STEP,
-        payload: { step },
+        payload: { call, step },
     };
 }
 
-export function setCallerLogMessage(message) {
+export function setCallerLogMessage(call, message) {
     return {
         type: types.SET_CALLER_LOG_MESSAGE,
-        payload: { message }
+        payload: { call, message }
     }
 }
 
-export function setOrganizerLogMessage(message) {
+export function setOrganizerLogMessage(call, message) {
     return {
         type: types.SET_ORGANIZER_LOG_MESSAGE,
-        payload: { message }
+        payload: { call, message }
     }
 }
 
-export function finishCallReport() {
+export function finishCallReport(call) {
     return {
         type: types.FINISH_CALL_REPORT,
+        payload: { call },
     }
 }
 
@@ -115,7 +116,7 @@ export function submitCallReport() {
         let state = getState();
         let call = currentCall(state);
         let callId = call.get('id');
-        let report = reportForCall(state, callId);
+        let report = reportForCallById(state, callId);
 
         let data = {
             notes: report.get('callerLog'),

--- a/src/components/call/CallProgressBar.jsx
+++ b/src/components/call/CallProgressBar.jsx
@@ -3,8 +3,8 @@ import React from 'react';
 export default function CallProgressBar(props) {
     let style;
 
-    if (props.call) {
-        let progress = props.call.get('progress');
+    if (props.lane) {
+        let progress = props.lane.get('progress');
         let pc = Math.ceil(progress * 100) + '%';
         style = { width: pc };
     }

--- a/src/components/call/LaneControlBar.jsx
+++ b/src/components/call/LaneControlBar.jsx
@@ -115,7 +115,7 @@ export default class LaneControlBar extends React.Component {
 
         return (
             <div className={ classes }>
-                <CallProgressBar key={ call? call.get('id') : '' } call={ call }/>
+                <CallProgressBar key={ call? call.get('id') : '' } lane={ lane }/>
                 <div className="LaneControlBar-returnSection">
                     { returnSection }
                 </div>

--- a/src/components/call/LaneControlBar.jsx
+++ b/src/components/call/LaneControlBar.jsx
@@ -48,7 +48,7 @@ export default class LaneControlBar extends React.Component {
                     onClick={ this.onClickStart.bind(this) }/>
             );
         }
-        else if (step === 'prepare') {
+        else if (step === 'prepare' && call) {
             let target = call.get('target');
 
             returnSection = (

--- a/src/components/panes/ReportPane.jsx
+++ b/src/components/panes/ReportPane.jsx
@@ -4,11 +4,11 @@ import { connect } from 'react-redux';
 
 import PaneBase from './PaneBase';
 import ReportForm from '../report/ReportForm';
-import { reportForCall } from '../../store/calls';
+import { reportForCallById } from '../../store/calls';
 
 
 const mapStateToProps = (state, props) => ({
-    report: reportForCall(state, props.call.get('id')),
+    report: reportForCallById(state, props.call.get('id')),
 });
 
 
@@ -33,7 +33,6 @@ export default class ReportPane extends PaneBase {
 
     renderContent() {
         let call = this.props.call;
-        let target = call.get('target');
         let report = this.props.report;
         let isComplete = this.props.step === 'done';
 
@@ -44,7 +43,7 @@ export default class ReportPane extends PaneBase {
         return [
             <Msg key="h1" tagName="h1" id={ h1Msg }/>,
             <ReportForm key="form"
-                report={ report } target={ target }
+                report={ report } call={ call }
                 disableEdit={ isComplete }/>
         ];
     }

--- a/src/components/report/ReportForm.jsx
+++ b/src/components/report/ReportForm.jsx
@@ -9,13 +9,15 @@ import { REPORT_STEPS } from '../../store/calls';
 @connect()
 export default class ReportForm extends React.Component {
     static propTypes = {
-        target: PropTypes.map.isRequired,
+        call: PropTypes.map.isRequired,
         report: PropTypes.map.isRequired,
         disableEdit: PropTypes.bool,
     };
 
     render() {
         let report = this.props.report;
+        let call = this.props.call;
+        let target = call.get('target');
         let steps = [];
 
         let curStepIndex = REPORT_STEPS.indexOf(report.get('step')) || 0;
@@ -25,8 +27,8 @@ export default class ReportForm extends React.Component {
 
             steps.push(
                 <StepComponent key={ step }
-                    target={ this.props.target }
                     dispatch={ this.props.dispatch }
+                    call={ call } target={ target }
                     step={ step } report={ report }
                     disableEdit={ this.props.disableEdit }/>
             );

--- a/src/components/report/steps/CallBackStep.jsx
+++ b/src/components/report/steps/CallBackStep.jsx
@@ -47,6 +47,7 @@ export default class CallBackStep extends ReportStepBase {
     }
 
     onClickOption(option) {
-        this.props.dispatch(setCallReportField('callBackAfter', option));
+        this.props.dispatch(setCallReportField(
+            this.props.call, 'callBackAfter', option));
     }
 }

--- a/src/components/report/steps/CallerLogStep.jsx
+++ b/src/components/report/steps/CallerLogStep.jsx
@@ -50,11 +50,12 @@ export default class CallerLogStep extends ReportStepBase {
     }
 
     onChangeMessage(ev) {
-        this.props.dispatch(setCallerLogMessage(ev.target.value));
+        this.props.dispatch(setCallerLogMessage(
+            this.props.call, ev.target.value));
     }
 
     onClickOption(organizerActionNeeded) {
-        this.props.dispatch(setCallReportField('organizerActionNeeded',
-            organizerActionNeeded));
+        this.props.dispatch(setCallReportField(
+            this.props.call, 'organizerActionNeeded', organizerActionNeeded));
     }
 }

--- a/src/components/report/steps/CouldTalkStep.jsx
+++ b/src/components/report/steps/CouldTalkStep.jsx
@@ -45,6 +45,7 @@ export default class CouldTalkStep extends ReportStepBase {
     }
 
     onClickOption(success) {
-        this.props.dispatch(setCallReportField('targetCouldTalk', success));
+        this.props.dispatch(setCallReportField(
+            this.props.call, 'targetCouldTalk', success));
     }
 }

--- a/src/components/report/steps/FailureMessageStep.jsx
+++ b/src/components/report/steps/FailureMessageStep.jsx
@@ -47,6 +47,7 @@ export default class FailureMessageStep extends ReportStepBase {
     }
 
     onClickOption(leftMessage) {
-        this.props.dispatch(setCallReportField('leftMessage', leftMessage));
+        this.props.dispatch(setCallReportField(
+            this.props.call, 'leftMessage', leftMessage));
     }
 }

--- a/src/components/report/steps/FailureReasonStep.jsx
+++ b/src/components/report/steps/FailureReasonStep.jsx
@@ -44,6 +44,7 @@ export default class FailureReasonStep extends ReportStepBase {
     }
 
     onClickOption(option) {
-        this.props.dispatch(setCallReportField('failureReason', option));
+        this.props.dispatch(setCallReportField(
+            this.props.call, 'failureReason', option));
     }
 }

--- a/src/components/report/steps/OrganizerLogStep.jsx
+++ b/src/components/report/steps/OrganizerLogStep.jsx
@@ -62,14 +62,16 @@ export default class OrganizerLogStep extends ReportStepBase {
     }
 
     onChangeMessage(ev) {
-        this.props.dispatch(setOrganizerLogMessage(ev.target.value));
+        this.props.dispatch(setOrganizerLogMessage(
+            this.props.call, ev.target.value));
     }
 
     onClickAdd() {
-        this.props.dispatch(finishCallReport());
+        this.props.dispatch(finishCallReport(this.props.call));
     }
 
     onClickRemove() {
-        this.props.dispatch(setCallReportField('organizerActionNeeded', false));
+        this.props.dispatch(setCallReportField(
+            this.props.call, 'organizerActionNeeded', false));
     }
 }

--- a/src/components/report/steps/ReportStepBase.jsx
+++ b/src/components/report/steps/ReportStepBase.jsx
@@ -9,6 +9,7 @@ import { setCallReportStep } from '../../../actions/call';
 
 export default class ReportStepBase extends React.Component {
     static propTypes = {
+        call: PropTypes.map.isRequired,
         step: PropTypes.string.isRequired,
         target: PropTypes.map.isRequired,
         report: PropTypes.map.isRequired,
@@ -68,6 +69,7 @@ export default class ReportStepBase extends React.Component {
     }
 
     onClickEdit() {
-        this.props.dispatch(setCallReportStep(this.props.step));
+        this.props.dispatch(setCallReportStep(
+            this.props.call, this.props.step));
     }
 }

--- a/src/components/report/steps/SuccessOrFailureStep.jsx
+++ b/src/components/report/steps/SuccessOrFailureStep.jsx
@@ -36,6 +36,7 @@ export default class SuccessOrFailureStep extends ReportStepBase {
     }
 
     onClickOption(success) {
-        this.props.dispatch(setCallReportField('success', success));
+        this.props.dispatch(setCallReportField(
+            this.props.call, 'success', success));
     }
 }

--- a/src/store/lanes.js
+++ b/src/store/lanes.js
@@ -126,15 +126,30 @@ export default createReducer(initialState, {
         if (selectedId === laneId) {
             selectedId = null;
             state.get('allLanes').forEach(lane => {
-                if (lane.get('id') !== selectedId) {
+                if (lane.get('id') !== laneId) {
                     selectedId = lane.get('id');
                 }
             });
         }
 
-        return state
-            .set('selectedId', selectedId)
-            .deleteIn(['allLanes', laneId]);
+        if (!selectedId) {
+            // This lane is the last one, so we should not remove it,
+            // but instead just reset it. Changing it's idea makes sure
+            // it's not rendered as the same lane but replaced.
+            let laneNumber = state.get('nextLaneNumber');
+            return state
+                .set('nextLaneNumber', laneNumber + 1)
+                .updateIn(['allLanes', laneId], lane => lane
+                    .set('id', laneNumber.toString())
+                    .set('step', 'assignment')
+                    .set('callId', null)
+                    .set('progress', 0.0));
+        }
+        else {
+            return state
+                .set('selectedId', selectedId)
+                .deleteIn(['allLanes', laneId]);
+        }
     },
 
     [types.SUBMIT_CALL_REPORT + '_FULFILLED']: (state, action) => {

--- a/src/store/lanes.js
+++ b/src/store/lanes.js
@@ -121,7 +121,19 @@ export default createReducer(initialState, {
         let laneId = state.get('allLanes')
             .findKey(lane => lane.get('callId') == callId);
 
+        let selectedId = state.get('selectedId');
+
+        if (selectedId === laneId) {
+            selectedId = null;
+            state.get('allLanes').forEach(lane => {
+                if (lane.get('id') !== selectedId) {
+                    selectedId = lane.get('id');
+                }
+            });
+        }
+
         return state
+            .set('selectedId', selectedId)
             .deleteIn(['allLanes', laneId]);
     },
 


### PR DESCRIPTION
This PR refactors the store so that identifiers for the currently selected call/lane is no longer duplicated across both the `lanes` and the `calls` keys. Instead, `lanes.selectedId` is now the single source of truth, and the current call is whichever is identified by the `lane.callId` attribute.

This fixes #42 and goes some way towards preparing the system for #37.