### PR TITLE
Past activity in TargetPane

### DIFF
--- a/locale/panes/sv.yaml
+++ b/locale/panes/sv.yaml
@@ -6,6 +6,14 @@ target:
     tagHeader: "Etiketter"
     callLogHeader: "Tidigare påringningar till {target}"
     instructionsButton: "Visa instruktioner"
+    activityHeader: "Tidigare aktivitet"
+    activityLastAction: "{activity} ({location}) {date}"
+    activityLabel: |
+        {count, plural,
+            =0 {{target} har aldrig deltagit i några aktioner.}
+            =1 {{target} har delagit i en aktion, {lastAction}.}
+            other {{target} har deltagit i {count} aktioner. Den senaste var {lastAction}.}
+        }
 
 input:
     h1: "Agera som { target }"

--- a/src/components/panes/TargetPane.jsx
+++ b/src/components/panes/TargetPane.jsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { connect } from 'react-redux';
-import { FormattedMessage as Msg } from 'react-intl';
+import { FormattedMessage as Msg, FormattedRelative } from 'react-intl';
 import querystring from 'querystring';
 
 import PaneBase from './PaneBase';
@@ -42,6 +42,30 @@ export default class TargetPane extends PaneBase {
             );
         }
 
+        let activityValues = {
+            target: target.get('first_name'),
+            count: target.getIn(['past_actions', 'num_actions']),
+        };
+
+        let lastAction = target.getIn(['past_actions', 'last_action']);
+        if (lastAction) {
+            let lastActionValues = {
+                activity: lastAction.getIn(['activity', 'title']),
+                location: lastAction.getIn(['location', 'title']),
+                date: (
+                    <FormattedRelative
+                        value={ new Date(lastAction.get('start_time')) }
+                        updateInterval={ 0 }
+                        />
+                )
+            };
+
+            activityValues.lastAction = (
+                <Msg tagName="em" id="panes.target.activityLastAction"
+                    values={ lastActionValues }/>
+            );
+        }
+
         return [
             <div key="basics" className="TargetPane-basics">
                 <Avatar personId={ target.get('id') }
@@ -57,6 +81,11 @@ export default class TargetPane extends PaneBase {
                 <Msg id="panes.target.tagHeader"/></h4>,
             <TagList key="tagList"
                 tags={ target.get('tags') }/>,
+            <h4 key="activityHeader" className="TargetPane-activityHeader">
+                <Msg id="panes.target.activityHeader"/>
+            </h4>,
+            <Msg key="activityLabel" id="panes.target.activityLabel"
+                values={ activityValues }/>,
             <h4 key="callLogHeader" className="TargetPane-callLogHeader">
                 <Msg id="panes.target.callLogHeader"
                     values={{ target: target.get('first_name') }}/>


### PR DESCRIPTION
This PR adds a section to `TargetPane` to describe target's past activity. Activity is described with a single string that can be one of three formats, as exemplified the following (Swedish localization only for now):

* Jane have never participated in an action.
* Jane participated in a single action, handing out flyers (Main Street) 4 months ago.
* Jane participated in 23 actions. The last one was handing out flyers (Main Street) 4 months ago.

Fixes #45.

## Screenshot of Swedish version below
![image](https://cloud.githubusercontent.com/assets/550212/20746071/858d262a-b6e4-11e6-8ddd-f88ade81ce78.png)