### PR TITLE
Lane switch improvements

### DIFF
--- a/locale/sv.yaml
+++ b/locale/sv.yaml
@@ -1,0 +1,11 @@
+misc:
+    laneSwitch:
+        toolTip:
+            h: "Gör om samtal"
+            p: |
+                Här kan du logga om ett tidigare samtal på nytt. Det är användbart
+                exempelvis om du blir uppringd av någon du sökt tidigare.
+            skipLink: "Jag förstår"
+            manualLink:
+                text: "Läs mer i manualen"
+                href: "http://manual.zetkin.org/sv/for-aktivister/ringa-med-zetkin/gora-om-ett-samtal/"

--- a/src/components/misc/laneSwitch/LaneSwitch.jsx
+++ b/src/components/misc/laneSwitch/LaneSwitch.jsx
@@ -1,6 +1,8 @@
 import React from 'react';
 import { connect } from 'react-redux';
+import { FormattedMessage as Msg, injectIntl } from 'react-intl';
 
+import FormattedLink from '../../../common/misc/FormattedLink';
 import LaneSwitchItem from './LaneSwitchItem';
 import PropTypes from '../../../utils/PropTypes';
 import { showOverlay } from '../../../actions/view';
@@ -15,8 +17,17 @@ const mapStateToProps = state => ({
 });
 
 
+@injectIntl
 @connect(mapStateToProps)
 export default class LaneSwitch extends React.Component {
+    constructor(props) {
+        super(props);
+
+        this.state = {
+            showInitialToolTip: true,
+        };
+    }
+
     render() {
         let overlay = this.props.overlay;
         let content;
@@ -28,7 +39,31 @@ export default class LaneSwitch extends React.Component {
                 .filter(call => call.get('id') != currentId)
                 .sortBy(call => call.get('id'));
 
+            let toolTip = null;
+            if (this.state.showInitialToolTip) {
+                let manualHref = this.props.intl.formatMessage(
+                    { id: 'misc.laneSwitch.toolTip.manualLink.href' });
+
+                toolTip = (
+                    <div key="toolTip"
+                        className="LaneSwitch-toolTip">
+                        <Msg tagName="h1" id="misc.laneSwitch.toolTip.h"/>
+                        <Msg tagName="p" id="misc.laneSwitch.toolTip.p"/>
+                        <p className="LaneSwitch-toolTipLinks">
+                            <FormattedLink
+                                msgId="misc.laneSwitch.toolTip.skipLink"
+                                onClick={ this.onSkipLinkClick.bind(this) }/>
+                            <FormattedLink
+                                target="_blank"
+                                msgId="misc.laneSwitch.toolTip.manualLink.text"
+                                href={ manualHref }/>
+                        </p>
+                    </div>
+                );
+            }
+
             content = [
+                toolTip,
                 <a key="openButton" className="LaneSwitch-openLogButton"
                     onClick={ this.onClickOpen.bind(this) }>log</a>,
                 <ul key="callList" className="LaneSwitch-callList">
@@ -50,6 +85,12 @@ export default class LaneSwitch extends React.Component {
                 { content }
             </div>
         );
+    }
+
+    onSkipLinkClick() {
+        this.setState({
+            showInitialToolTip: false,
+        });
     }
 
     onClickOtherCall(call) {

--- a/src/components/misc/laneSwitch/LaneSwitch.jsx
+++ b/src/components/misc/laneSwitch/LaneSwitch.jsx
@@ -98,6 +98,10 @@ export default class LaneSwitch extends React.Component {
     }
 
     onClickOpen() {
+        this.setState({
+            showInitialToolTip: false,
+        });
+
         this.props.dispatch(showOverlay('laneOverview'));
     }
 }

--- a/src/components/misc/laneSwitch/LaneSwitch.jsx
+++ b/src/components/misc/laneSwitch/LaneSwitch.jsx
@@ -65,7 +65,8 @@ export default class LaneSwitch extends React.Component {
             content = [
                 toolTip,
                 <a key="openButton" className="LaneSwitch-openLogButton"
-                    onClick={ this.onClickOpen.bind(this) }>log</a>,
+                    onClick={ this.onClickOpen.bind(this) }>
+                    <i className="fa-phone"/></a>,
                 <ul key="callList" className="LaneSwitch-callList">
                 { otherCalls.map(call => (
                     <LaneSwitchItem key={ call.get('id') } call={ call }

--- a/src/components/misc/laneSwitch/LaneSwitch.scss
+++ b/src/components/misc/laneSwitch/LaneSwitch.scss
@@ -18,4 +18,55 @@
         padding: 0;
         float: left;
     }
+
+    .LaneSwitch-toolTip {
+        padding: 0.7em 1em;
+        max-width: 400px;
+        box-shadow: 0 0 10px 0 rgba(0,0,0,0.3);
+        border-radius: 0.5em;
+
+        position: relative;
+        bottom: 1em;
+        background-color: white;
+        z-index: 1;
+
+        &:after {
+            content: "\00a0";
+            display: block;
+            position: absolute;
+            width: 1em;
+            height: 1em;
+            background-color: white;
+            bottom: -0.5em;
+            left: 12px;
+            z-index: 0;
+            transform: rotate(-45deg);
+            box-shadow: -3px 3px 5px 0 rgba(0,0,0,0.1);
+        }
+
+        h1 {
+            font-size: 1em;
+            margin: 0;
+        }
+
+        p {
+            font-size: 0.8em;
+            margin: 0.5em 0 0;
+
+            &.LaneSwitch-toolTipLinks {
+                text-align: right;
+            }
+        }
+
+        a {
+            display: inline-block;
+            margin: 0 0.5em;
+            cursor: pointer;
+            text-decoration: underline;
+
+            &:hover {
+                color: darken($c-brand-main, 30%);
+            }
+        }
+    }
 }

--- a/src/components/misc/laneSwitch/LaneSwitch.scss
+++ b/src/components/misc/laneSwitch/LaneSwitch.scss
@@ -8,9 +8,17 @@
         float: left;
         width: 40px;
         height: 40px;
-        background-color: red;
+        padding: 10px;
+        background-color: $c-brand-main;
         border-radius: 50%;
         box-shadow: 2px 2px 10px rgba(0,0,0,0.3);
+        color: white;
+        font: normal normal normal 20px/1 FontAwesome;
+        cursor: pointer;
+
+        &:hover {
+            background-color: darken($c-brand-main, 10%);
+        }
     }
 
     .LaneSwitch-callList {


### PR DESCRIPTION
This PR improves the `LaneSwitch` components in a few simple ways:

* Adds a tool tip which is visible when LaneSwitch is first added to the DOM (could eventually be shown only once using cookies or similar solution).
* Adds some nicer styling to the log button, including an icon.

![image](https://cloud.githubusercontent.com/assets/550212/20751921/c2c73610-b6fe-11e6-9699-81eb4e824f35.png)
