### PR TITLE
More complete report UX

### DIFF
--- a/locale/report/steps/sv.yaml
+++ b/locale/report/steps/sv.yaml
@@ -1,12 +1,12 @@
 successOrFailure:
-    question: "Fick du prata med någon?"
+    question: "Nådde du {target}?"
     options:
         success: "Ja"
         failure: "Nej..."
 
     summary:
-        success: "Du nådde fram."
-        failure: "Du nådde inte fram."
+        success: "Du nådde {target}."
+        failure: "Du nådde inte {target}."
 
 successCouldTalk:
     question: "Kunde {target} prata just nu?"
@@ -34,12 +34,13 @@ failureReason:
     question: "Varför inte?"
     options:
         noPickup: "Inget svar / telefonsvarare"
+        notAvailable: "Inte tillgänglig just nu"
         wrongNumber: "Fel nummer"
         lineBusy: "Upptaget"
     summary:
-        noPickup: "Personen svarade inte."
-        otherPerson: "Du pratade med en annan person."
-        wrongNumber: "Vi hade fel nummer till personen."
+        noPickup: "{target} svarade inte."
+        notAvailable: "{target} var inte tillgänglig just nu."
+        wrongNumber: "Vi hade fel nummer till {target}."
         lineBusy: "Det var upptaget."
 
 failureMessage:

--- a/locale/report/steps/sv.yaml
+++ b/locale/report/steps/sv.yaml
@@ -17,7 +17,7 @@ successCouldTalk:
         couldTalk: "{target} kunde prata med oss."
         callBack: "{target} hade inte tid att prata just nu."
 
-successCallBack:
+callBack:
     question: "När ska vi ringa tillbaka?"
     options:
         asap: "Så snart som möjligt"

--- a/src/actions/call.js
+++ b/src/actions/call.js
@@ -147,6 +147,7 @@ export function submitCallReport() {
 
         // TODO: Respect "leftMessage" once API supports it
         // TODO: Send along organizerLog once API supports it
+        // TODO: Better way to handle failed calls + CBA
         if (report.get('success')) {
             if (report.get('targetCouldTalk')) {
                 // Successful call!
@@ -176,6 +177,27 @@ export function submitCallReport() {
                 }
 
                 data.call_back_after = date.iso();
+            }
+        }
+        else if (report.get('failureReason') == 'notAvailable') {
+            data.state = 13;
+
+            let date = new Date();
+            date.setUTC(true);
+
+            switch (report.get('callBackAfter')) {
+                case 'fewDays':
+                    date.advance('2 days');
+                    data.call_back_after = date.iso();
+                    break;
+                case 'oneWeek':
+                    date.advance('7 days');
+                    data.call_back_after = date.iso();
+                    break;
+                case 'twoWeeks':
+                    date.advance('14 days');
+                    data.call_back_after = date.iso();
+                    break;
             }
         }
         else {

--- a/src/components/report/ReportForm.jsx
+++ b/src/components/report/ReportForm.jsx
@@ -46,9 +46,9 @@ const componentFromStep = step => {
     return {
         success_or_failure: steps.SuccessOrFailureStep,
         success_could_talk: steps.CouldTalkStep,
-        success_call_back: steps.CallBackStep,
         failure_reason: steps.FailureReasonStep,
         failure_message: steps.FailureMessageStep,
+        call_back: steps.CallBackStep,
         caller_log: steps.CallerLogStep,
         organizer_log: steps.OrganizerLogStep,
         summary: steps.SummaryStep,

--- a/src/components/report/steps/CallBackStep.jsx
+++ b/src/components/report/steps/CallBackStep.jsx
@@ -28,25 +28,25 @@ export default class CallBackStep extends ReportStepBase {
     renderForm(report) {
         return [
             <Msg key="question" tagName="p"
-                id="report.steps.successCallBack.question"/>,
+                id="report.steps.callBack.question"/>,
             <Button key="noResponseButton"
-                labelMsg="report.steps.successCallBack.options.asap"
+                labelMsg="report.steps.callBack.options.asap"
                 onClick={ this.onClickOption.bind(this, 'asap') }/>,
             <Button key="otherPersonButton"
-                labelMsg="report.steps.successCallBack.options.fewDays"
+                labelMsg="report.steps.callBack.options.fewDays"
                 onClick={ this.onClickOption.bind(this, 'fewDays') }/>,
             <Button key="wrongNumberButton"
-                labelMsg="report.steps.successCallBack.options.oneWeek"
+                labelMsg="report.steps.callBack.options.oneWeek"
                 onClick={ this.onClickOption.bind(this, 'oneWeek') }/>,
             <Button key="lineBusyButton"
-                labelMsg="report.steps.successCallBack.options.twoWeeks"
+                labelMsg="report.steps.callBack.options.twoWeeks"
                 onClick={ this.onClickOption.bind(this, 'twoWeeks') }/>,
         ];
     }
 
     renderSummary(report) {
         let cba = report.get('callBackAfter');
-        let msgId = 'report.steps.successCallBack.summary.' + cba;
+        let msgId = 'report.steps.callBack.summary.' + cba;
 
         return (
             <Msg tagName="p" id={ msgId }/>

--- a/src/components/report/steps/CallBackStep.jsx
+++ b/src/components/report/steps/CallBackStep.jsx
@@ -8,12 +8,19 @@ import { setCallReportField } from '../../../actions/call';
 
 export default class CallBackStep extends ReportStepBase {
     getRenderMode(report) {
-        if (!report.get('success') || report.get('targetCouldTalk')) {
-            // Don't render this step for failed calls
+        if (report.get('success') && report.get('targetCouldTalk')) {
+            // Don't render this step for successfull calls where
+            // the target had time to talk right now.
+            return 'none';
+        }
+        else if (!report.get('success')
+            && report.get('failureReason') !== 'notAvailable') {
+            // Don't render this step for failed calls unless the
+            // reason was that caller is not available
             return 'none';
         }
         else {
-            return (report.get('step') === 'success_call_back')?
+            return (report.get('step') === 'call_back')?
                 'form' : 'summary';
         }
     }

--- a/src/components/report/steps/FailureReasonStep.jsx
+++ b/src/components/report/steps/FailureReasonStep.jsx
@@ -31,6 +31,9 @@ export default class FailureReasonStep extends ReportStepBase {
             <Button key="lineBusyButton"
                 labelMsg="report.steps.failureReason.options.lineBusy"
                 onClick={ this.onClickOption.bind(this, 'lineBusy') }/>,
+            <Button key="notAvailableButton"
+                labelMsg="report.steps.failureReason.options.notAvailable"
+                onClick={ this.onClickOption.bind(this, 'notAvailable') }/>,
         ];
     }
 

--- a/src/components/report/steps/FailureReasonStep.jsx
+++ b/src/components/report/steps/FailureReasonStep.jsx
@@ -39,10 +39,11 @@ export default class FailureReasonStep extends ReportStepBase {
 
     renderSummary(report) {
         let reason = report.get('failureReason');
+        let target = this.props.target.get('first_name');
         let msgId = 'report.steps.failureReason.summary.' + reason;
 
         return (
-            <Msg tagName="p" id={ msgId }/>
+            <Msg tagName="p" id={ msgId } values={{ target }}/>
         );
     }
 

--- a/src/components/report/steps/SuccessOrFailureStep.jsx
+++ b/src/components/report/steps/SuccessOrFailureStep.jsx
@@ -13,9 +13,11 @@ export default class SuccessOrFailureStep extends ReportStepBase {
     }
 
     renderForm(report) {
+        let target = this.props.target.get('first_name');
         return [
             <Msg key="question" tagName="p"
-                id="report.steps.successOrFailure.question"/>,
+                id="report.steps.successOrFailure.question"
+                values={{ target }}/>,
             <Button key="yesButton"
                 labelMsg="report.steps.successOrFailure.options.success"
                 onClick={ this.onClickOption.bind(this, true) }/>,

--- a/src/store/calls.js
+++ b/src/store/calls.js
@@ -41,9 +41,9 @@ const initialState = immutable.Map({
 export const REPORT_STEPS = [
     'success_or_failure',
     'success_could_talk',
-    'success_call_back',
     'failure_reason',
     'failure_message',
+    'call_back',
     'caller_log',
     'organizer_log',
     'summary',
@@ -206,7 +206,7 @@ export default createReducer(initialState, {
             nextStep = 'caller_log';
         }
         else if (field === 'targetCouldTalk' && !value) {
-            nextStep = 'success_call_back';
+            nextStep = 'call_back';
         }
         else if (field === 'callBackAfter') {
             nextStep = 'caller_log';
@@ -216,6 +216,9 @@ export default createReducer(initialState, {
         }
         else if (field === 'failureReason' && value === "noPickup") {
             nextStep = 'failure_message';
+        }
+        else if (field === 'failureReason' && value === "notAvailable") {
+            nextStep = 'call_back';
         }
         else if (field === 'failureReason') {
             nextStep = 'caller_log';

--- a/src/store/lanes.js
+++ b/src/store/lanes.js
@@ -24,9 +24,9 @@ const initialState = immutable.fromJS({
 const REPORT_STEP_PROGRESS = {
     'success_or_failure': 0.0,
     'success_could_talk': 0.2,
-    'success_call_back': 0.4,
     'failure_reason': 0.2,
     'failure_message': 0.4,
+    'call_back': 0.4,
     'caller_log': 0.6,
     'organizer_log': 0.8,
     'summary': 1.0,
@@ -215,7 +215,7 @@ export default createReducer(initialState, {
             nextStep = 'caller_log';
         }
         else if (field === 'targetCouldTalk' && !value) {
-            nextStep = 'success_call_back';
+            nextStep = 'call_back';
         }
         else if (field === 'callBackAfter') {
             nextStep = 'caller_log';
@@ -225,6 +225,9 @@ export default createReducer(initialState, {
         }
         else if (field === 'failureReason' && value === "noPickup") {
             nextStep = 'failure_message';
+        }
+        else if (field === 'failureReason' && value === 'notAvailable') {
+            nextStep = 'call_back';
         }
         else if (field === 'failureReason') {
             nextStep = 'caller_log';


### PR DESCRIPTION
This PR modifies the report flow such that more scenarios are properly covered. In particular, before this PR, cases where someone close to the target, but not the actual target, picks up to let caller know that target will be available at some other time. PR #32 made this worse in the process of fixing a similar but not identical case which was not properly accommodated by the original report flow.

The new flow is seen depicted below. Although not visualized as such in the chart, the "call back" step can now be considered part of the final stretch after the success and failure branches converge.

![image](https://cloud.githubusercontent.com/assets/550212/20754220/3b566a8c-b70a-11e6-8ae3-0ddd26be0623.png)
[Read details here](https://docs.google.com/document/d/1eHKR1i9qUEzxdNg9EqZQNLpbTBnzRqiSGZOeTLPU860).

Fixes #35.