### PR TITLE
Revamped report flow

### DIFF
--- a/locale/report/steps/sv.yaml
+++ b/locale/report/steps/sv.yaml
@@ -52,23 +52,29 @@ failureMessage:
         leftMessage: "Du lämnade ett meddelande."
         noMessage: "Du lämnade inget meddelande."
 
-callerLog:
-    callerQuestion: "Lämna en anteckning till framtida ringare"
-    organizerQuestion: "Behöver en organisatör agera?"
+organizerAction:
+    question: "Framkom något under samtalet som kräver att en ansvarig agerar?"
     options:
-        organizerActionNeeded: "Ja"
+        actionNeeded: "Ja"
         noActionNeeded: "Nej, det behövs inte"
     summary:
-        leftLog: "Du lämnade en anteckning till framtida ringare:"
-        emptyLog: "Du lämnade ingen anteckning till ringare."
+        actionNeeded: "Du vill att någon ansvarig kollar på samtalet."
+        noActionNeeded: "Ingen ansvarig behöver agera."
 
 organizerLog:
-    question: "Förklara för organisatören vad problemet är."
+    question: "Förklara för den som är ansvarig vad problemet är."
     options:
         saveWithoutLog: "Spara utan meddelande"
         saveWithLog: "Inkludera meddelandet"
-        noActionNeeded: "Organisatör behövs inte"
     summary:
-        leftLog: "Du lämnade en anteckning för organistörer att uppmärksamma:"
-        emptyLog: "Du har bett en organisatör titta på samtalet."
-        noActionNeeded: "Ingen organisatör behöver titta på meddelandet"
+        leftLog: "Du skrev en anteckning till den ansvariga."
+        emptyLog: "Du skrev ingen anteckning till den ansvariga."
+
+callerLog:
+    question: "Vill du lämna en anteckning till framtida ringare?"
+    options:
+        saveWithLog: "Spara anteckning"
+        saveWithoutLog: "Spara utan anteckning"
+    summary:
+        leftLog: "Du skrev en anteckning till framtida ringare."
+        emptyLog: "Du skrev ingen anteckning till framtida ringare."

--- a/locale/report/steps/sv.yaml
+++ b/locale/report/steps/sv.yaml
@@ -3,10 +3,12 @@ successOrFailure:
     options:
         success: "Ja"
         failure: "Nej..."
-
     summary:
         success: "Du nådde {target}."
         failure: "Du nådde inte {target}."
+    effect:
+        success: "Framtida ringare kommer se att du pratat med {target}."
+        failure: "Framtida ringare kommer se att du inte pratat med {target}."
 
 successCouldTalk:
     question: "Kunde {target} prata just nu?"
@@ -16,6 +18,9 @@ successCouldTalk:
     summary:
         couldTalk: "{target} kunde prata med oss."
         callBack: "{target} hade inte tid att prata just nu."
+    effect:
+        couldTalk: "Framtida ringare kommer se att ni kunde prata färdigt."
+        callBack: "Framtida ringare kommer se att vi behövde ringa tillbaka."
 
 callBack:
     question: "När ska vi ringa tillbaka?"
@@ -29,6 +34,9 @@ callBack:
         fewDays: "Vi ringer tillbaka tidigast om ett par dagar"
         oneWeek: "Vi ringer tillbaka tidigast om en vecka"
         twoWeeks: "Vi ringer tillbaka tidigast om två veckor"
+    effect:
+        asap: "{target} placeras sist i ringkön."
+        other: "{target} plockas automatiskt bort ur ringkön så länge."
 
 failureReason:
     question: "Varför inte?"
@@ -51,6 +59,8 @@ failureMessage:
     summary:
         leftMessage: "Du lämnade ett meddelande."
         noMessage: "Du lämnade inget meddelande."
+    effect:
+        leftMessage: "Framtida ringare kommer att se att du lämnat ett meddelande."
 
 organizerAction:
     question: "Framkom något under samtalet som kräver att en ansvarig agerar?"
@@ -60,6 +70,8 @@ organizerAction:
     summary:
         actionNeeded: "Du vill att någon ansvarig kollar på samtalet."
         noActionNeeded: "Ingen ansvarig behöver agera."
+    effect:
+        actionNeeded: "En organisatör kommer bli meddelad."
 
 organizerLog:
     question: "Förklara för den som är ansvarig vad problemet är."
@@ -67,8 +79,10 @@ organizerLog:
         saveWithoutLog: "Spara utan meddelande"
         saveWithLog: "Inkludera meddelandet"
     summary:
-        leftLog: "Du skrev en anteckning till den ansvariga."
-        emptyLog: "Du skrev ingen anteckning till den ansvariga."
+        leftLog: "Du skrev en anteckning till organisatören."
+        emptyLog: "Du skrev ingen anteckning till organisatören."
+    effect:
+        leftLog: "Organisatören kommer få följande meddelande:"
 
 callerLog:
     question: "Vill du lämna en anteckning till framtida ringare?"
@@ -78,3 +92,5 @@ callerLog:
     summary:
         leftLog: "Du skrev en anteckning till framtida ringare."
         emptyLog: "Du skrev ingen anteckning till framtida ringare."
+    effect:
+        leftLog: "Framtida ringare kommer att se din anteckning:"

--- a/src/components/report/ReportForm.jsx
+++ b/src/components/report/ReportForm.jsx
@@ -49,6 +49,7 @@ const componentFromStep = step => {
         failure_reason: steps.FailureReasonStep,
         failure_message: steps.FailureMessageStep,
         call_back: steps.CallBackStep,
+        organizer_action: steps.OrganizerActionStep,
         caller_log: steps.CallerLogStep,
         organizer_log: steps.OrganizerLogStep,
         summary: steps.SummaryStep,

--- a/src/components/report/steps/CallBackStep.jsx
+++ b/src/components/report/steps/CallBackStep.jsx
@@ -53,6 +53,17 @@ export default class CallBackStep extends ReportStepBase {
         );
     }
 
+    renderEffect(report) {
+        let target = this.props.target.get('first_name');
+        let cba = report.get('callBackAfter');
+        let msgId = 'report.steps.callBack.effect.' + ((cba === 'asap')?
+            'asap' : 'other');
+
+        return (
+            <Msg tagName="p" id={ msgId } values={{ target }}/>
+        );
+    }
+
     onClickOption(option) {
         this.props.dispatch(setCallReportField(
             this.props.call, 'callBackAfter', option));

--- a/src/components/report/steps/CallerLogStep.jsx
+++ b/src/components/report/steps/CallerLogStep.jsx
@@ -4,7 +4,7 @@ import { FormattedMessage as Msg } from 'react-intl';
 import Button from '../../../common/misc/Button';
 import ReportStepBase from './ReportStepBase';
 import {
-    setCallReportField,
+    finishCallReport,
     setCallerLogMessage,
 } from '../../../actions/call';
 
@@ -16,19 +16,19 @@ export default class CallerLogStep extends ReportStepBase {
     }
 
     renderForm(report) {
+        let log = report.get('callerLog');
+        let saveLabelMsg = log.length?
+            'report.steps.callerLog.options.saveWithLog' :
+            'report.steps.callerLog.options.saveWithoutLog';
+
         return [
-            <Msg key="callerQuestion" tagName="p"
-                id="report.steps.callerLog.callerQuestion"/>,
+            <Msg key="question" tagName="p"
+                id="report.steps.callerLog.question"/>,
             <textarea key="message" value={ report.get('callerLog') }
                 onChange={ this.onChangeMessage.bind(this) }/>,
-            <Msg key="organizerQuestion" tagName="p"
-                id="report.steps.callerLog.organizerQuestion"/>,
-            <Button key="messageButton"
-                labelMsg="report.steps.callerLog.options.organizerActionNeeded"
-                onClick={ this.onClickOption.bind(this, true) }/>,
-            <Button key="noMessageButton"
-                labelMsg="report.steps.callerLog.options.noActionNeeded"
-                onClick={ this.onClickOption.bind(this, false) }/>,
+            <Button key="saveButton"
+                labelMsg={ saveLabelMsg }
+                onClick={ this.onClickSave.bind(this) }/>,
         ];
     }
 
@@ -54,8 +54,7 @@ export default class CallerLogStep extends ReportStepBase {
             this.props.call, ev.target.value));
     }
 
-    onClickOption(organizerActionNeeded) {
-        this.props.dispatch(setCallReportField(
-            this.props.call, 'organizerActionNeeded', organizerActionNeeded));
+    onClickSave() {
+        this.props.dispatch(finishCallReport(this.props.call));
     }
 }

--- a/src/components/report/steps/CallerLogStep.jsx
+++ b/src/components/report/steps/CallerLogStep.jsx
@@ -35,17 +35,30 @@ export default class CallerLogStep extends ReportStepBase {
     renderSummary(report) {
         let log = report.get('callerLog') || '';
         if (log.length) {
-            return [
-                <Msg key="summary" tagName="p"
-                    id="report.steps.callerLog.summary.leftLog"/>,
-                <p key="log" className="logMessage">{ log }</p>
-            ];
+            return (
+                <Msg tagName="p"
+                    id="report.steps.callerLog.summary.leftLog"/>
+            );
         }
         else {
             return (
                 <Msg tagName="p"
                     id="report.steps.callerLog.summary.emptyLog"/>
             );
+        }
+    }
+
+    renderEffect(report) {
+        let log = report.get('callerLog') || '';
+        if (log.length) {
+            return [
+                <Msg key="effect" tagName="p"
+                    id="report.steps.callerLog.effect.leftLog"/>,
+                <p key="log" className="logMessage">{ log }</p>
+            ];
+        }
+        else {
+            return null;
         }
     }
 

--- a/src/components/report/steps/CouldTalkStep.jsx
+++ b/src/components/report/steps/CouldTalkStep.jsx
@@ -44,6 +44,16 @@ export default class CouldTalkStep extends ReportStepBase {
         );
     }
 
+    renderEffect(report) {
+        let msgId = report.get('targetCouldTalk')?
+            'report.steps.successCouldTalk.effect.couldTalk' :
+            'report.steps.successCouldTalk.effect.callBack';
+
+        return (
+            <Msg tagName="p" id={ msgId }/>
+        );
+    }
+
     onClickOption(success) {
         this.props.dispatch(setCallReportField(
             this.props.call, 'targetCouldTalk', success));

--- a/src/components/report/steps/FailureMessageStep.jsx
+++ b/src/components/report/steps/FailureMessageStep.jsx
@@ -46,6 +46,18 @@ export default class FailureMessageStep extends ReportStepBase {
         );
     }
 
+    renderEffect(report) {
+        if (report.get('leftMessage')) {
+            return (
+                <Msg tagName="p"
+                    id="report.steps.failureMessage.effect.leftMessage"/>
+            );
+        }
+        else {
+            return null;
+        }
+    }
+
     onClickOption(leftMessage) {
         this.props.dispatch(setCallReportField(
             this.props.call, 'leftMessage', leftMessage));

--- a/src/components/report/steps/OrganizerActionStep.jsx
+++ b/src/components/report/steps/OrganizerActionStep.jsx
@@ -27,16 +27,28 @@ export default class OrganizerActionStep extends ReportStepBase {
 
     renderSummary(report) {
         if (report.get('organizerActionNeeded')) {
-            return [
-                <Msg key="summary" tagName="p"
-                    id="report.steps.organizerAction.summary.actionNeeded"/>,
-            ];
+            return (
+                <Msg tagName="p"
+                    id="report.steps.organizerAction.summary.actionNeeded"/>
+            );
         }
         else {
             return (
                 <Msg tagName="p"
                     id="report.steps.organizerAction.summary.noActionNeeded"/>
             );
+        }
+    }
+
+    renderEffect(report) {
+        if (report.get('organizerActionNeeded')) {
+            return (
+                <Msg tagName="p"
+                    id="report.steps.organizerAction.effect.actionNeeded"/>
+            );
+        }
+        else {
+            return null;
         }
     }
 

--- a/src/components/report/steps/OrganizerActionStep.jsx
+++ b/src/components/report/steps/OrganizerActionStep.jsx
@@ -1,0 +1,47 @@
+import React from 'react';
+import { FormattedMessage as Msg } from 'react-intl';
+
+import Button from '../../../common/misc/Button';
+import ReportStepBase from './ReportStepBase';
+import { setCallReportField } from '../../../actions/call';
+
+
+export default class OrganizerActionStep extends ReportStepBase {
+    getRenderMode(report) {
+        return (report.get('step') === 'organizer_action')?
+            'form' : 'summary';
+    }
+
+    renderForm(report) {
+        return [
+            <Msg key="callerQuestion" tagName="p"
+                id="report.steps.organizerAction.question"/>,
+            <Button key="actionButton"
+                labelMsg="report.steps.organizerAction.options.actionNeeded"
+                onClick={ this.onClickOption.bind(this, true) }/>,
+            <Button key="noActionButton"
+                labelMsg="report.steps.organizerAction.options.noActionNeeded"
+                onClick={ this.onClickOption.bind(this, false) }/>,
+        ];
+    }
+
+    renderSummary(report) {
+        if (report.get('organizerActionNeeded')) {
+            return [
+                <Msg key="summary" tagName="p"
+                    id="report.steps.organizerAction.summary.actionNeeded"/>,
+            ];
+        }
+        else {
+            return (
+                <Msg tagName="p"
+                    id="report.steps.organizerAction.summary.noActionNeeded"/>
+            );
+        }
+    }
+
+    onClickOption(organizerActionNeeded) {
+        this.props.dispatch(setCallReportField(
+            this.props.call, 'organizerActionNeeded', organizerActionNeeded));
+    }
+}

--- a/src/components/report/steps/OrganizerLogStep.jsx
+++ b/src/components/report/steps/OrganizerLogStep.jsx
@@ -42,17 +42,31 @@ export default class OrganizerLogStep extends ReportStepBase {
         let log = report.get('organizerLog') || '';
 
         if (oan && log.length) {
-            return [
-                <Msg key="summary" tagName="p"
-                    id="report.steps.organizerLog.summary.leftLog"/>,
-                <p key="log" className="logMessage">{ log }</p>
-            ];
+            return (
+                <Msg tagName="p"
+                    id="report.steps.organizerLog.summary.leftLog"/>
+            );
         }
         else if (oan) {
             return (
                 <Msg tagName="p"
                     id="report.steps.organizerLog.summary.emptyLog"/>
             );
+        }
+    }
+
+    renderEffect(report) {
+        let log = report.get('organizerLog') || '';
+
+        if (log.length) {
+            return [
+                <Msg key="effect" tagName="p"
+                    id="report.steps.organizerLog.effect.leftLog"/>,
+                <p key="log" className="logMessage">{ log }</p>
+            ];
+        }
+        else {
+            return null;
         }
     }
 

--- a/src/components/report/steps/OrganizerLogStep.jsx
+++ b/src/components/report/steps/OrganizerLogStep.jsx
@@ -6,14 +6,20 @@ import ReportStepBase from './ReportStepBase';
 import {
     finishCallReport,
     setCallReportField,
+    setCallReportStep,
     setOrganizerLogMessage,
 } from '../../../actions/call';
 
 
 export default class OrganizerLogStep extends ReportStepBase {
     getRenderMode(report) {
-        return (report.get('step') === 'organizer_log')?
-            'form' : 'summary';
+        if (report.get('organizerActionNeeded')) {
+            return (report.get('step') === 'organizer_log')?
+                'form' : 'summary';
+        }
+        else {
+            return 'none';
+        }
     }
 
     renderForm(report) {
@@ -53,12 +59,6 @@ export default class OrganizerLogStep extends ReportStepBase {
                     id="report.steps.organizerLog.summary.emptyLog"/>
             );
         }
-        else {
-            return (
-                <Msg tagName="p"
-                    id="report.steps.organizerLog.summary.noActionNeeded"/>
-            );
-        }
     }
 
     onChangeMessage(ev) {
@@ -67,7 +67,7 @@ export default class OrganizerLogStep extends ReportStepBase {
     }
 
     onClickAdd() {
-        this.props.dispatch(finishCallReport(this.props.call));
+        this.props.dispatch(setCallReportStep(this.props.call, 'caller_log'));
     }
 
     onClickRemove() {

--- a/src/components/report/steps/OrganizerLogStep.jsx
+++ b/src/components/report/steps/OrganizerLogStep.jsx
@@ -4,8 +4,6 @@ import { FormattedMessage as Msg } from 'react-intl';
 import Button from '../../../common/misc/Button';
 import ReportStepBase from './ReportStepBase';
 import {
-    finishCallReport,
-    setCallReportField,
     setCallReportStep,
     setOrganizerLogMessage,
 } from '../../../actions/call';
@@ -31,9 +29,6 @@ export default class OrganizerLogStep extends ReportStepBase {
         return [
             <Msg key="organizerQuestion" tagName="p"
                 id="report.steps.organizerLog.question"/>,
-            <Button key="noActionButton"
-                labelMsg="report.steps.organizerLog.options.noActionNeeded"
-                onClick={ this.onClickRemove.bind(this) }/>,
             <textarea key="message" value={ report.get('organizerLog') }
                 onChange={ this.onChangeMessage.bind(this) }/>,
             <Button key="saveButton"
@@ -68,10 +63,5 @@ export default class OrganizerLogStep extends ReportStepBase {
 
     onClickAdd() {
         this.props.dispatch(setCallReportStep(this.props.call, 'caller_log'));
-    }
-
-    onClickRemove() {
-        this.props.dispatch(setCallReportField(
-            this.props.call, 'organizerActionNeeded', false));
     }
 }

--- a/src/components/report/steps/ReportStepBase.jsx
+++ b/src/components/report/steps/ReportStepBase.jsx
@@ -29,10 +29,27 @@ export default class ReportStepBase extends React.Component {
             let editLink = null;
 
             if (renderMode === 'form') {
-                content = this.renderForm(report);
+                content = (
+                    <div className="ReportStepBase-form">
+                        { this.renderForm(report) }
+                    </div>
+                );
             }
             else if (renderMode === 'summary') {
-                content = this.renderSummary(report);
+                content = [
+                    <div key="summary" className="ReportStepBase-summary">
+                        { this.renderSummary(report) }
+                    </div>
+                ];
+
+                let effect = this.renderEffect(report);
+                if (effect) {
+                    content.push(
+                        <div key="effect" className="ReportStepBase-effect">
+                            { effect }
+                        </div>
+                    );
+                }
 
                 if (!this.props.disableEdit) {
                     editLink = (
@@ -52,9 +69,7 @@ export default class ReportStepBase extends React.Component {
             return (
                 <div className={ cx(classNames) }>
                     { editLink }
-                    <div className="ReportStepBase-content">
-                        { content }
-                    </div>
+                    { content }
                 </div>
             );
         }
@@ -66,6 +81,10 @@ export default class ReportStepBase extends React.Component {
         // * summary - to render brief summary
         // * none - to not render at all
         return 'none';
+    }
+
+    renderEffect(report) {
+        return null;
     }
 
     onClickEdit() {

--- a/src/components/report/steps/ReportStepBase.scss
+++ b/src/components/report/steps/ReportStepBase.scss
@@ -23,8 +23,8 @@
         }
     }
 
-    .ReportStepBase-content {
-        .button {
+    .ReportStepBase-form {
+        .Button {
             @include button(#f9f9f9);
 
             margin: 0 0.5em 0.5em 0;

--- a/src/components/report/steps/SuccessOrFailureStep.jsx
+++ b/src/components/report/steps/SuccessOrFailureStep.jsx
@@ -32,6 +32,18 @@ export default class SuccessOrFailureStep extends ReportStepBase {
         let msgId = report.get('success')?
             'report.steps.successOrFailure.summary.success' :
             'report.steps.successOrFailure.summary.failure';
+
+        return (
+            <Msg tagName="p" id={ msgId } values={{ target }}/>
+        );
+    }
+
+    renderEffect(report) {
+        let target = this.props.target.get('first_name');
+        let msgId = report.get('success')?
+            'report.steps.successOrFailure.effect.success' :
+            'report.steps.successOrFailure.effect.failure';
+
         return (
             <Msg tagName="p" id={ msgId } values={{ target }}/>
         );

--- a/src/components/report/steps/index.js
+++ b/src/components/report/steps/index.js
@@ -4,5 +4,6 @@ export CallBackStep from './CallBackStep';
 export FailureReasonStep from './FailureReasonStep';
 export FailureMessageStep from './FailureMessageStep';
 export CallerLogStep from './CallerLogStep';
+export OrganizerActionStep from './OrganizerActionStep';
 export OrganizerLogStep from './OrganizerLogStep';
 export SummaryStep from './SummaryStep';

--- a/src/store/calls.js
+++ b/src/store/calls.js
@@ -44,8 +44,9 @@ export const REPORT_STEPS = [
     'failure_reason',
     'failure_message',
     'call_back',
-    'caller_log',
+    'organizer_action',
     'organizer_log',
+    'caller_log',
     'summary',
 ];
 
@@ -203,13 +204,13 @@ export default createReducer(initialState, {
             nextStep = 'success_could_talk';
         }
         else if (field === 'targetCouldTalk' && value) {
-            nextStep = 'caller_log';
+            nextStep = 'organizer_action';
         }
         else if (field === 'targetCouldTalk' && !value) {
             nextStep = 'call_back';
         }
         else if (field === 'callBackAfter') {
-            nextStep = 'caller_log';
+            nextStep = 'organizer_action';
         }
         else if (field === 'success') {
             nextStep = 'failure_reason';
@@ -221,16 +222,16 @@ export default createReducer(initialState, {
             nextStep = 'call_back';
         }
         else if (field === 'failureReason') {
-            nextStep = 'caller_log';
+            nextStep = 'organizer_action';
         }
         else if (field === 'leftMessage') {
-            nextStep = 'caller_log';
+            nextStep = 'organizer_action';
         }
         else if (field === 'organizerActionNeeded' && value) {
             nextStep = 'organizer_log';
         }
         else if (field === 'organizerActionNeeded') {
-            nextStep = 'summary';
+            nextStep = 'caller_log';
         }
 
         return state

--- a/src/store/lanes.js
+++ b/src/store/lanes.js
@@ -28,8 +28,9 @@ const REPORT_STEP_PROGRESS = {
     'failure_reason': 0.2,
     'failure_message': 0.4,
     'call_back': 0.4,
-    'caller_log': 0.6,
-    'organizer_log': 0.8,
+    'organizer_action': 0.5,
+    'organizer_log': 0.6,
+    'caller_log': 0.8,
     'summary': 1.0,
 };
 
@@ -213,13 +214,13 @@ export default createReducer(initialState, {
             nextStep = 'success_could_talk';
         }
         else if (field === 'targetCouldTalk' && value) {
-            nextStep = 'caller_log';
+            nextStep = 'organizer_action';
         }
         else if (field === 'targetCouldTalk' && !value) {
             nextStep = 'call_back';
         }
         else if (field === 'callBackAfter') {
-            nextStep = 'caller_log';
+            nextStep = 'organizer_action';
         }
         else if (field === 'success') {
             nextStep = 'failure_reason';
@@ -231,16 +232,16 @@ export default createReducer(initialState, {
             nextStep = 'call_back';
         }
         else if (field === 'failureReason') {
-            nextStep = 'caller_log';
+            nextStep = 'organizer_action';
         }
         else if (field === 'leftMessage') {
-            nextStep = 'caller_log';
+            nextStep = 'organizer_action';
         }
         else if (field === 'organizerActionNeeded' && value) {
             nextStep = 'organizer_log';
         }
         else if (field === 'organizerActionNeeded') {
-            nextStep = 'summary';
+            nextStep = 'caller_log';
         }
 
         let reportProgress = REPORT_STEP_PROGRESS[nextStep];


### PR DESCRIPTION
This PR revamps the report flow to fix issues discovered during the december 2016 user testing.

* Change order of report questions so that questions about organizer action comes before the caller log notes. (Relevant to #73)
* Re-phrase report questions to accommodate issues raised in #71 and #72.
* Add "effect" captions to report steps to describe what the user input will result in. (Relevant to #70 and #71)