### PR TITLE
Misc user test issues fixed

### DIFF
--- a/src/actions/lane.js
+++ b/src/actions/lane.js
@@ -1,4 +1,5 @@
 import * as types from '.';
+import { laneByCallId } from '../store/lanes';
 
 
 export function setLaneStep(lane, step) {
@@ -15,11 +16,20 @@ export function setLaneInfoMode(mode) {
     };
 }
 
-export function switchLaneToCall(call) {
-    let callId = call.get('id');
+export function switchLaneToCall(call, step) {
+    return ({ dispatch, getState }) => {
+        let callId = call.get('id');
 
-    return {
-        type: types.SWITCH_LANE_TO_CALL,
-        payload: { callId },
+        dispatch({
+            type: types.SWITCH_LANE_TO_CALL,
+            payload: { callId },
+        });
+
+        if (step) {
+            console.log(JSON.stringify(callId));
+            let lane = laneByCallId(getState().get('lanes'), callId.toString());
+
+            dispatch(setLaneStep(lane, step));
+        }
     };
 }

--- a/src/components/misc/callOpList/CallOpListItem.jsx
+++ b/src/components/misc/callOpList/CallOpListItem.jsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import { FormattedRelative } from 'react-intl';
 
 import Avatar from '../Avatar';
 import PropTypes from '../../../utils/PropTypes';
@@ -12,6 +13,7 @@ export default class CallOpListItem extends React.Component {
     render() {
         let call = this.props.call;
         let target = call.get('target');
+        let date = new Date(call.get('allocation_time'));
 
         return (
             <div className="CallOpListItem">
@@ -24,7 +26,7 @@ export default class CallOpListItem extends React.Component {
                     { target.get('name') }
                 </span>
                 <span className="CallOpListItem-time">
-                    { call.get('allocation_time') }
+                    <FormattedRelative value={ date }/>
                 </span>
 
                 <div className="CallOpListItem-ops">

--- a/src/components/overlays/LaneOverview.jsx
+++ b/src/components/overlays/LaneOverview.jsx
@@ -63,9 +63,11 @@ export default class LaneOverview extends React.Component {
             };
 
             // Exclude calls that are merely allocated. They will be in the
-            // adjacent lanes list anyway.
+            // adjacent lanes list anyway. Finally order calls by date.
             let calls = callList.get('items').toList()
-                .filter(c => c.get('state') !== 0);
+                .filter(c => c.get('state') !== 0)
+                .sortBy(c => c.get('allocation_time'))
+                .reverse();
 
             let filterString = this.state.filterString.toLowerCase();
             if (filterString.length > 2) {

--- a/src/components/overlays/ResumeOverlay.jsx
+++ b/src/components/overlays/ResumeOverlay.jsx
@@ -42,7 +42,7 @@ export default class ResumeOverlay extends React.Component {
 
     onCallOperation(call, op) {
         if (op == 'resume') {
-            this.props.dispatch(switchLaneToCall(call));
+            this.props.dispatch(switchLaneToCall(call, 'call'));
         }
         else if (op == 'discard') {
             this.props.dispatch(deallocateCall(call));


### PR DESCRIPTION
This PR adds some minor changes geared towards fixing issues discovered during the December 2016 user tests.

* Resuming a call (after crash or on return to Zetkin Call) now starts in the "call" step, as suggested in #93.
* The call list in `LaneOverview` is now sorted by allocation time, most recent first. Fixes #81 