### PR TITLE
Scrollbar visibility & styling 

### DIFF
--- a/src/components/overlays/OverlayStack.scss
+++ b/src/components/overlays/OverlayStack.scss
@@ -20,6 +20,18 @@
         padding: 10%;
         overflow-y: scroll;
 
+        &::-webkit-scrollbar {
+            width: 10px;
+        }
+
+        &::-webkit-scrollbar-thumb {
+            background-color: darken(white,70);
+
+            &:hover {
+                background-color: darken(white,60);
+            }
+        }
+
         &:after {
             content: "";
             display: block;

--- a/src/components/overlays/OverlayStack.scss
+++ b/src/components/overlays/OverlayStack.scss
@@ -20,17 +20,7 @@
         padding: 10%;
         overflow-y: scroll;
 
-        &::-webkit-scrollbar {
-            width: 10px;
-        }
-
-        &::-webkit-scrollbar-thumb {
-            background-color: darken(white,70);
-
-            &:hover {
-                background-color: darken(white,60);
-            }
-        }
+        @include scrollbar(lighten(black, 20), $flip:true);
 
         &:after {
             content: "";

--- a/src/components/panes/PaneBase.scss
+++ b/src/components/panes/PaneBase.scss
@@ -72,6 +72,12 @@
         overflow-y: scroll;
         overflow-x: hidden;
 
+        &:hover {
+            &::-webkit-scrollbar {
+                background-color: darken(white,1.5);
+            }
+        }
+
         &::-webkit-scrollbar {
             width: 10px;
         }

--- a/src/components/panes/PaneBase.scss
+++ b/src/components/panes/PaneBase.scss
@@ -3,7 +3,7 @@
     overflow: visible;
     top: 0;
     bottom: 0;
-    padding: 0 0 1em 1em;
+    padding: 0 0 0em 1em;
     background: none;
     box-sizing: border-box;
     box-shadow: 0 2px 2px darken(#FFF, 10);
@@ -67,9 +67,23 @@
         background: white;
         height: calc(100% - 4em);
         margin-top: 4em;
-        overflow: scroll;
         padding-right: 3%;
         padding-top: 1em;
+        overflow-y: scroll;
+        overflow-x: hidden;
+
+        &::-webkit-scrollbar {
+            width: 10px;
+        }
+
+        &::-webkit-scrollbar-thumb {
+            background-color: darken(white,5);
+
+            &:hover {
+                background-color: darken(white,8);
+                cursor: pointer;
+            }
+        }
 
         h1 {
             &:first-child {

--- a/src/components/panes/PaneBase.scss
+++ b/src/components/panes/PaneBase.scss
@@ -72,23 +72,10 @@
         overflow-y: scroll;
         overflow-x: hidden;
 
+        @include scrollbar(white);
+
         &:hover {
-            &::-webkit-scrollbar {
-                background-color: darken(white,1.5);
-            }
-        }
-
-        &::-webkit-scrollbar {
-            width: 10px;
-        }
-
-        &::-webkit-scrollbar-thumb {
-            background-color: darken(white,5);
-
-            &:hover {
-                background-color: darken(white,8);
-                cursor: pointer;
-            }
+            @include scrollbar(darken(white, 5));
         }
 
         h1 {

--- a/src/scss/_global.scss
+++ b/src/scss/_global.scss
@@ -8,6 +8,7 @@ body {
     background-color: #FFF;
     font-size: 15px;
     margin: 0;
+    overflow: hidden;
 
     @include large-screen {
         font-size: 18px;

--- a/src/scss/_global.scss
+++ b/src/scss/_global.scss
@@ -40,7 +40,3 @@ a {
 p {
     line-height: 1.7em;
 }
-
-::-webkit-scrollbar {
-    display: none;
-}

--- a/src/scss/_mixins.scss
+++ b/src/scss/_mixins.scss
@@ -152,6 +152,40 @@
     }
 }
 
+
+@mixin scrollbar($color:white, $flip: false) {
+
+    &::-webkit-scrollbar {
+        width: 10px;
+    }
+
+    @if $flip {
+        &::-webkit-scrollbar-thumb {
+            background-color: lighten($color,5);
+
+            &:hover {
+                background-color: lighten($color,8);
+            }
+        }
+    }
+
+    @else {
+        &:hover {
+            &::-webkit-scrollbar {
+                background-color: darken(white,1.5);
+            }
+        }
+
+        &::-webkit-scrollbar-thumb {
+            background-color: darken($color,5);
+
+            &:hover {
+                background-color: darken($color,8);
+            }
+        }
+    }
+}
+
 @mixin col ($col, $sum, $gap: 0.5em, $align: top, $first: false, $last: false) {
     width: percentage($col/$sum);
     vertical-align: $align;


### PR DESCRIPTION
This PR aim to solve #86.

Since scrollbar affects the elements width, adding it only on hover opens a can of worms across browsers.

Ended up with the following:
- Show vertical scrollbars on PaneBase-content.
- Style scrollbars for webkit browsers.

## Chrome / Safari: 
![skarmavbild 2016-12-13 kl 18 37 40](https://cloud.githubusercontent.com/assets/1271517/21152793/2187d0b0-c168-11e6-8ecc-9b04cfcf3f1a.png)
(TargetPane has a hover on the scroll thumb).

![skarmavbild 2016-12-13 kl 19 33 02](https://cloud.githubusercontent.com/assets/1271517/21153531/2e503686-c16b-11e6-8aaf-9df86beceefd.png)


## Firefox:
<img width="1552" alt="skarmavbild 2016-12-13 kl 18 49 53" src="https://cloud.githubusercontent.com/assets/1271517/21152784/1522ee18-c168-11e6-9735-5d6a71c758b8.png">

