### PR TITLE
Prominent filter input in LaneOverview

### DIFF
--- a/src/components/overlays/LaneOverview.jsx
+++ b/src/components/overlays/LaneOverview.jsx
@@ -99,6 +99,7 @@ export default class LaneOverview extends React.Component {
                         id="overlays.laneOverview.log.h"/>
                     <Msg tagName="p"
                         id="overlays.laneOverview.log.p"/>
+                    <i className="fa fa-search"></i>
                     <input type="text"
                         placeholder={ filterPlaceholder }
                         value={ this.state.filterString }

--- a/src/components/overlays/LaneOverview.jsx
+++ b/src/components/overlays/LaneOverview.jsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import ReactDOM from 'react-dom';
 import { FormattedMessage as Msg, injectIntl } from 'react-intl';
 import { connect } from 'react-redux';
 
@@ -31,6 +32,11 @@ export default class LaneOverview extends React.Component {
 
     componentDidMount() {
         this.props.dispatch(retrieveUserCalls());
+
+        let filterInput = ReactDOM.findDOMNode(this.refs.filterInput);
+        if (filterInput) {
+            filterInput.focus();
+        }
     }
 
     render() {
@@ -100,7 +106,7 @@ export default class LaneOverview extends React.Component {
                     <Msg tagName="p"
                         id="overlays.laneOverview.log.p"/>
                     <i className="fa fa-search"></i>
-                    <input type="text"
+                    <input type="text" ref="filterInput"
                         placeholder={ filterPlaceholder }
                         value={ this.state.filterString }
                         onKeyUp={ this.onFilterKeyUp.bind(this) }

--- a/src/components/overlays/LaneOverview.scss
+++ b/src/components/overlays/LaneOverview.scss
@@ -3,15 +3,24 @@
         float: left;
         width: 45%;
         margin: 0 2.5%;
+
+        p {
+            margin-bottom: 2em;
+        }
+    }
+
+    i {
+        width: 5%;
     }
 
     input[type="text"] {
-        width: 100%;
+        width: 95%;
         border: 0;
         border-bottom: 1px solid white;
         padding: 0.5em;
         margin-bottom: 1em;
         font-size: 1em;
+
         &:focus {
             outline: none;
             border-bottom-color: $c-brand-comp-light;


### PR DESCRIPTION
- Adding search icon to input field for filtering in LaneOverview.
- Increase margins to top to distinguish from previous content and pair with the list. 

Since input tag doesn't have content, it also lacks psudo elements. This means that we can't use our standard method to add icon through sass in the :before element. Therefor, we need to add a i tag in jsx.

![skarmavbild 2016-12-14 kl 16 45 48](https://cloud.githubusercontent.com/assets/1271517/21189287/7bb820a6-c21e-11e6-8cc0-80873792860a.png)

Closes #80 