### PR TITLE
Empty queue handling

### DIFF
--- a/locale/panes/sv.yaml
+++ b/locale/panes/sv.yaml
@@ -47,3 +47,11 @@ stats:
     p: |
         Din insats är viktig för att bygga din organisation
         starkare. Här är en sammanfattning av hur det går.
+
+queueEmpty:
+    h1: "Slut på personer att ringa!"
+    p: |
+        Just nu finns det inga fler personer i kön. Om en stund kan det hända
+        att fler släpps på, men för tillfället kan du inte ringa mer på det
+        här uppdraget.
+    assignmentsLink: "Välj ett annat uppdrag"

--- a/src/components/call/CallLane.jsx
+++ b/src/components/call/CallLane.jsx
@@ -51,6 +51,9 @@ export default class CallLane extends React.Component {
             case 'done':
                 paneComponents = [ 'report', 'stats' ];
                 break;
+            case 'empty':
+                paneComponents = [ 'empty' ];
+                break;
         }
 
         let panes = paneComponents.map(paneType => {
@@ -86,6 +89,7 @@ export default class CallLane extends React.Component {
 
 const paneComponentsByType = {
     assignment: panes.AssignmentPane,
+    empty: panes.QueueEmptyPane,
     instructions: panes.InstructionsPane,
     input: panes.InputPane,
     report: panes.ReportPane,

--- a/src/components/call/CallLane.scss
+++ b/src/components/call/CallLane.scss
@@ -55,6 +55,18 @@
     &.CallPage-leave {
         animation: CallLane-leaveAnimation 0.5s;
     }
+
+    &.CallLane-emptyStep {
+        .AssignmentPane.PaneBase-leave {
+            animation: AssignmentPane-leaveForEmptyAnimation $pane-transition-duration;
+        }
+    }
+}
+
+@keyframes AssignmentPane-leaveForEmptyAnimation {
+    to {
+        left: -100%;
+    }
 }
 
 @keyframes CallLane-enterAnimation {

--- a/src/components/panes/AssignmentPane.scss
+++ b/src/components/panes/AssignmentPane.scss
@@ -3,7 +3,7 @@
     left: 0;
 
     &.PaneBase-leave {
-        animation: AssignmentPane-leaveAnimation 0.5s;
+        animation: AssignmentPane-leaveForPrepareAnimation $pane-transition-duration;
     }
 
     .PaneBase-content {
@@ -16,7 +16,7 @@
     }
 }
 
-@keyframes AssignmentPane-leaveAnimation {
+@keyframes AssignmentPane-leaveForPrepareAnimation {
     to {
         left: -65%;
     }

--- a/src/components/panes/InputPane.scss
+++ b/src/components/panes/InputPane.scss
@@ -181,11 +181,11 @@
     }
 
     &.PaneBase-enter {
-        animation: InputPane-enterAnimation 0.5s;
+        animation: InputPane-enterAnimation $pane-transition-duration;
     }
 
     &.InputPane-firstCall.PaneBase-enter {
-        animation: InputPane-firstCall-enterAnimation 0.5s;
+        animation: InputPane-firstCall-enterAnimation $pane-transition-duration;
     }
 }
 

--- a/src/components/panes/PaneBase.scss
+++ b/src/components/panes/PaneBase.scss
@@ -8,7 +8,7 @@
     box-sizing: border-box;
     box-shadow: 0 2px 2px darken(#FFF, 10);
 
-    transition: width 0.5s, left 0.5s;
+    transition: width $pane-transition-duration, left $pane-transition-duration;
 
     h1 {
         font-size: 1.7em;
@@ -87,11 +87,11 @@
 }
 
 .PaneBase-enter {
-    animation: PaneBase-enterAnimation 0.5s;
+    animation: PaneBase-enterAnimation $pane-transition-duration;
 }
 
 .PaneBase-leave {
-    animation: PaneBase-leaveAnimation 0.5s;
+    animation: PaneBase-leaveAnimation $pane-transition-duration;
 }
 
 @keyframes PaneBase-enterAnimation {

--- a/src/components/panes/QueueEmptyPane.jsx
+++ b/src/components/panes/QueueEmptyPane.jsx
@@ -11,6 +11,7 @@ export default class QueueEmptyPane extends PaneBase {
             <Msg key="h1" tagName="h1" id="panes.queueEmpty.h1"/>,
             <Msg key="p" tagName="p" id="panes.queueEmpty.p"/>,
             <FormattedLink key="assignmentsLink"
+                className="QueueEmptyPane-assignmentsLink"
                 href="/assignments"
                 msgId="panes.queueEmpty.assignmentsLink"/>,
         ];

--- a/src/components/panes/QueueEmptyPane.jsx
+++ b/src/components/panes/QueueEmptyPane.jsx
@@ -1,0 +1,18 @@
+import React from 'react';
+import { FormattedMessage as Msg } from 'react-intl';
+
+import PaneBase from './PaneBase';
+import FormattedLink from '../../common/misc/FormattedLink';
+
+
+export default class QueueEmptyPane extends PaneBase {
+    renderContent() {
+        return [
+            <Msg key="h1" tagName="h1" id="panes.queueEmpty.h1"/>,
+            <Msg key="p" tagName="p" id="panes.queueEmpty.p"/>,
+            <FormattedLink key="assignmentsLink"
+                href="/assignments"
+                msgId="panes.queueEmpty.assignmentsLink"/>,
+        ];
+    }
+}

--- a/src/components/panes/QueueEmptyPane.scss
+++ b/src/components/panes/QueueEmptyPane.scss
@@ -1,0 +1,5 @@
+.QueueEmptyPane {
+    width: 100%;
+    left: 0;
+    z-index: 10;
+}

--- a/src/components/panes/QueueEmptyPane.scss
+++ b/src/components/panes/QueueEmptyPane.scss
@@ -2,4 +2,18 @@
     width: 100%;
     left: 0;
     z-index: 10;
+
+    .PaneBase-content {
+        text-align: center;
+        margin-top: 2em;
+
+        p {
+            max-width: 40em;
+            margin: 0 auto 1em;
+        }
+
+        .QueueEmptyPane-assignmentsLink {
+            @include button();
+        }
+    }
 }

--- a/src/components/panes/ReportPane.scss
+++ b/src/components/panes/ReportPane.scss
@@ -1,5 +1,5 @@
 .ReportPane {
-    transition: left 0.5s;
+    transition: left $pane-transition-duration;
 
     .PaneBase-header {
         p {
@@ -52,7 +52,7 @@
     }
 
     &.PaneBase-leave {
-        animation: ReportPane-leaveAnimation 0.5s;
+        animation: ReportPane-leaveAnimation $pane-transition-duration;
     }
 }
 

--- a/src/components/panes/StatsPane.scss
+++ b/src/components/panes/StatsPane.scss
@@ -7,7 +7,7 @@
     }
 
     &.PaneBase-leave {
-        animation: StatsPane-leaveAnimation 0.5s;
+        animation: StatsPane-leaveAnimation $pane-transition-duration;
     }
 }
 

--- a/src/components/panes/TargetPane.scss
+++ b/src/components/panes/TargetPane.scss
@@ -110,16 +110,16 @@
 
     &.PaneBase-enter {
         // Use custom animation in general, but...
-        animation: TargetPane-enterAnimation 0.5s;
+        animation: TargetPane-enterAnimation $pane-transition-duration;
     }
 
     &.TargetPane-firstCall.PaneBase-enter {
         // ...use standard animation for first call
-        animation: PaneBase-enterAnimation 0.5s;
+        animation: PaneBase-enterAnimation $pane-transition-duration;
     }
 
     &.PaneBase-leave {
-        animation: TargetPane-leaveAnimation 0.5s;
+        animation: TargetPane-leaveAnimation $pane-transition-duration;
     }
 }
 

--- a/src/components/panes/index.js
+++ b/src/components/panes/index.js
@@ -4,3 +4,4 @@ export InputPane from './InputPane';
 export ReportPane from './ReportPane';
 export StatsPane from './StatsPane';
 export TargetPane from './TargetPane';
+export QueueEmptyPane from './QueueEmptyPane';

--- a/src/scss/_variables.scss
+++ b/src/scss/_variables.scss
@@ -24,3 +24,6 @@ $c-ui-darker: darken($c-ui-bg, 50);
 // Responsive breakpoints
 $medium-min-width: 720px;
 $wide-min-width: 1024px;
+
+// Timing
+$pane-transition-duration: 0.5s;

--- a/src/store/lanes.js
+++ b/src/store/lanes.js
@@ -100,6 +100,20 @@ export default createReducer(initialState, {
             .setIn(['allLanes', laneId, 'step'], 'prepare');
     },
 
+    [types.START_NEW_CALL + '_REJECTED']: (state, action) => {
+        let laneId = state.get('selectedId');
+
+        return state
+            .setIn(['allLanes', laneId, 'step'], 'empty');
+    },
+
+    [types.SKIP_CALL + '_REJECTED']: (state, action) => {
+        let laneId = state.get('selectedId');
+
+        return state
+            .setIn(['allLanes', laneId, 'step'], 'empty');
+    },
+
     [types.START_CALL_WITH_TARGET + '_FULFILLED']: (state, action) => {
         let call = action.payload.data.data;
         let callId = call.id.toString();

--- a/src/store/view.js
+++ b/src/store/view.js
@@ -38,6 +38,11 @@ export default createReducer(initialState, {
             .set('overlay', null);
     },
 
+    [types.SKIP_CALL + '_REJECTED']: (state, action) => {
+        return state
+            .set('overlay', null);
+    },
+
     [types.SWITCH_LANE_TO_CALL]: (state, action) => {
         return state
             .set('overlay', null);


### PR DESCRIPTION
This PR adds logic and interface for handling when the queue is empty and the `head` endpoint returns an(y) error.

Regardless of whether the case is the result of a skip or trying to start a new call (the first one, or after reporting another), the _empty_ step is entered, and the `QueueEmptyPane` (both introduced by this PR) is shown.

Fixes #61