### PR TITLE
Login after 401 errors

### DIFF
--- a/src/store/index.js
+++ b/src/store/index.js
@@ -4,6 +4,8 @@ import immutable from 'immutable';
 import { intlReducer } from 'react-intl-redux';
 import promiseMiddleware from 'redux-promise-middleware';
 
+import loginRedirect from '../common/redux/middleware/loginRedirect';
+
 import actions from './actions';
 import assignments from './assignments';
 import calls from './calls';
@@ -38,6 +40,7 @@ export const configureStore = (initialState, z) => {
     let middleware = [
         promiseMiddleware(),
         thunkWithZ,
+        loginRedirect(process.env.ZETKIN_APP_ID, process.env.ZETKIN_DOMAIN),
     ];
 
     let devTools = f => f;

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -1,7 +1,7 @@
 var path = require('path');
 var webpack = require('webpack');
 
-var appId = process.env.ZETKIN_APP_ID || 'a4';
+var appId = process.env.ZETKIN_APP_ID || 'a5';
 
 module.exports = {
     entry: [


### PR DESCRIPTION
This PR uses the `loginRedirect` middleware recently added to `zetkin-common` to redirect the user to the login page after any 401 error.