### PR TITLE
Narrow screen adjustments

### DIFF
--- a/src/components/call/CallLane.scss
+++ b/src/components/call/CallLane.scss
@@ -12,6 +12,10 @@
         top: 90px;
         right: 0;
         overflow: hidden;
+
+        @include large-screen {
+            top: 100px;
+        }
     }
 
     &.CallLane-instructionsInfoMode {
@@ -63,10 +67,6 @@
             animation: AssignmentPane-leaveForEmptyAnimation $pane-transition-duration;
         }
     }
-}
-
-@include large-screen {
-    top: 100px;
 }
 
 @keyframes AssignmentPane-leaveForEmptyAnimation {

--- a/src/components/call/CallLane.scss
+++ b/src/components/call/CallLane.scss
@@ -9,7 +9,7 @@
         position: absolute;
         bottom: 0;
         left: 0;
-        top: 100px;
+        top: 90px;
         right: 0;
         overflow: hidden;
     }
@@ -63,6 +63,10 @@
             animation: AssignmentPane-leaveForEmptyAnimation $pane-transition-duration;
         }
     }
+}
+
+@include large-screen {
+    top: 100px;
 }
 
 @keyframes AssignmentPane-leaveForEmptyAnimation {

--- a/src/components/call/LaneControlBar.scss
+++ b/src/components/call/LaneControlBar.scss
@@ -3,7 +3,7 @@
     top: 0;
     left: 0;
     right: 0;
-    height: 100px;
+    height: 90px;
     padding: 1em;
     box-shadow: 0 2px 5px darken(#FFF, 10);
     overflow: hidden;
@@ -70,5 +70,9 @@
         .LaneControlBar-content {
 
         }
+    }
+
+    @include large-screen {
+        height: 100px;
     }
 }

--- a/src/components/call/LaneControlBar.scss
+++ b/src/components/call/LaneControlBar.scss
@@ -4,13 +4,13 @@
     left: 0;
     right: 0;
     height: 90px;
-    padding: 1em;
+    padding: 1em 0;
     box-shadow: 0 2px 5px darken(#FFF, 10);
     overflow: hidden;
     z-index: 99;
 
     .LaneControlBar-returnSection {
-        @include col(3,12)
+        @include col(4,12)
         text-align: left;
         padding-top: 0.5em;
         .Button {
@@ -19,7 +19,7 @@
     }
 
     .LaneControlBar-content {
-        @include col(4,12);
+        @include col(4,12)
         text-align: left;
         transition: top 0.4s, left 0.4s;
 
@@ -36,7 +36,7 @@
     }
 
     .LaneControlBar-proceedSection {
-        @include col(5,12)
+        @include col(4,12)
         text-align: right;
         padding-top: 0.5em;
 
@@ -51,6 +51,12 @@
             @include button(darken(white, 5), $icon: $fa-var-step-forward);
             background: 0;
             font-size: 0.8em;
+            visibility: hidden;
+            width: 3em;
+
+            &:before {
+                visibility: visible;
+            }
         }
     }
 
@@ -74,5 +80,18 @@
 
     @include large-screen {
         height: 100px;
+
+        .LaneControlBar-returnSection {
+            @include col(3,12)
+        }
+
+        .LaneControlBar-proceedSection {
+            @include col(5,12);
+
+            .LaneControlBar-skipButton {
+                visibility: visible;
+                width: auto;
+            }
+        }
     }
 }

--- a/src/components/call/LaneControlBar.scss
+++ b/src/components/call/LaneControlBar.scss
@@ -65,10 +65,19 @@
             display: none;
         }
         .LaneControlBar-content {
-            @include col(7,12);
+            @include col(7.5,12);
         }
         .LaneControlBar-proceedSection {
-            @include col(5,12)
+            @include col(4.5,12)
+        }
+
+        @include large-screen {
+            .LaneControlBar-content {
+                @include col(7,12);
+            }
+            .LaneControlBar-proceedSection {
+                @include col(5,12)
+            }
         }
     }
 

--- a/src/components/call/LaneControlBar.scss
+++ b/src/components/call/LaneControlBar.scss
@@ -10,7 +10,7 @@
     z-index: 99;
 
     .LaneControlBar-returnSection {
-        @include col(4,12)
+        @include col(3,12)
         text-align: left;
         padding-top: 0.5em;
         .Button {
@@ -20,7 +20,7 @@
 
     .LaneControlBar-content {
         @include col(4,12);
-        text-align: center;
+        text-align: left;
         transition: top 0.4s, left 0.4s;
 
         h1 {
@@ -29,11 +29,14 @@
 
         p {
             color: darken(white, 30);
+            &:before {
+                @include icon($fa-var-info-circle);
+            }
         }
     }
 
     .LaneControlBar-proceedSection {
-        @include col(4,12)
+        @include col(5,12)
         text-align: right;
         padding-top: 0.5em;
 

--- a/src/components/call/TargetInfo.scss
+++ b/src/components/call/TargetInfo.scss
@@ -15,8 +15,12 @@
     }
 
     .TargetInfo-name, .TargetInfo-number {
-        font-size: 1.3em;
+        font-size: 1.1em;
         line-height: 1.5em;
+
+        @include large-screen {
+            font-size: 1.3em;
+        }
     }
 
     .TargetInfo-name {

--- a/src/components/call/TargetInfo.scss
+++ b/src/components/call/TargetInfo.scss
@@ -39,7 +39,11 @@
     }
 
     .TargetInfo-lastCall {
-        font-size: 0.8em;
+        font-size: 0.7em;
+
+        @include large-screen {
+            font-size: 0.8em;
+        }
 
         &:before {
             content: "- ";

--- a/src/components/panes/PaneBase.scss
+++ b/src/components/panes/PaneBase.scss
@@ -65,7 +65,7 @@
 
     .PaneBase-content {
         background: white;
-        height: calc(100% - 4em);
+        height: calc(100% - 3.5em);
         margin-top: 3.5em;
         padding-right: 3%;
         padding-top: 0.3em;

--- a/src/components/panes/ReportPane.scss
+++ b/src/components/panes/ReportPane.scss
@@ -20,11 +20,17 @@
         .ReportPane-backLink {
             @include col(4,12);
             display: inline-block;
-            line-height: 4em;
+            line-height: 4.5em;
             cursor: pointer;
+            font-size: 0.8em;
 
             &:before {
                 @include icon($fa-var-arrow-left);
+            }
+
+            @include large-screen {
+                @include col(4,12);
+                visibility: visible;
             }
 
             &:hover {

--- a/src/components/panes/TargetPane.scss
+++ b/src/components/panes/TargetPane.scss
@@ -12,19 +12,21 @@
     .Avatar {
         float: left;
         padding-left: 0;
-        height: 8em;
-        width: 8em;
+        height: 0;
+        background-size: contain;
+        padding-top: 33%;
+        @include col(4,12);
     }
 
     .TargetPane-name {
-        @include col(8,12);
+        @include col(12,12);
         float: right;
         margin-bottom: 0.5em;
         font-size: 1.3em;
     }
 
     .TargetPane-info {
-        @include col(8,12);
+        @include col(12,12);
         list-style: none;
         float: right;
 
@@ -122,6 +124,17 @@
         animation: TargetPane-leaveAnimation $pane-transition-duration;
     }
 }
+
+
+@include large-screen {
+    .Avatar {
+        @include col(4,12);
+    }
+    .TargetPane-name, .TargetPane-info {
+        @include col(8,12);
+    }
+}
+
 
 @keyframes TargetPane-enterAnimation {
     from {

--- a/src/components/panes/TargetPane.scss
+++ b/src/components/panes/TargetPane.scss
@@ -33,6 +33,9 @@
         li {
             margin-bottom: 0.5em;
             font-size: 0.8em;
+            text-overflow: ellipsis;
+            white-space: nowrap;
+            overflow: hidden;
         }
     }
 

--- a/src/components/panes/TargetPane.scss
+++ b/src/components/panes/TargetPane.scss
@@ -130,11 +130,13 @@
 
 
 @include large-screen {
-    .Avatar {
-        @include col(4,12);
-    }
-    .TargetPane-name, .TargetPane-info {
-        @include col(8,12);
+    .TargetPane {
+        .Avatar {
+            @include col(4,12);
+        }
+        .TargetPane-name, .TargetPane-info {
+            @include col(8,12);
+        }
     }
 }
 

--- a/src/scss/_variables.scss
+++ b/src/scss/_variables.scss
@@ -22,7 +22,7 @@ $c-ui-dark: darken($c-ui-bg, 30);
 $c-ui-darker: darken($c-ui-bg, 50);
 
 // Responsive breakpoints
-$medium-min-width: 720px;
+$medium-min-width: 768px;
 $wide-min-width: 1024px;
 
 // Timing

--- a/src/scss/_variables.scss
+++ b/src/scss/_variables.scss
@@ -23,7 +23,7 @@ $c-ui-darker: darken($c-ui-bg, 50);
 
 // Responsive breakpoints
 $medium-min-width: 768px;
-$wide-min-width: 1024px;
+$wide-min-width: 1125px;
 
 // Timing
 $pane-transition-duration: 0.5s;


### PR DESCRIPTION
This PR adjusts different widths and sizes on elements that previously had problems on narrow screens. 

The UI is now adjusted to be used with iPad landscape as minimum. Though pane width is not optimal for iPad portrait, nothing breaks. 

In future, we will need to revisit this as we allow < 768px screens.

Fixes #23 