### PR TITLE
Feature catchup with platform

### DIFF
--- a/locale/campaignForm/en.yaml
+++ b/locale/campaignForm/en.yaml
@@ -4,7 +4,7 @@ action:
         signUp: Sign up
         undoSignUp: Undo Sign up
     currentNeed: More activists needed here
-    infoButton: Read more
+    infoButton: Info
     multiLocationLabel: |
         {count, plural,
             =2 {In two locations}

--- a/locale/campaignForm/sv.yaml
+++ b/locale/campaignForm/sv.yaml
@@ -1,10 +1,10 @@
 action:
     booked: Bokad
     button:
-        signUp: Anmäl dig
+        signUp: Anmäl
         undoSignUp: Ångra anmälan
     currentNeed: Fler aktivister behövs här
-    infoButton: Läs mer
+    infoButton: Info
     multiLocationLabel: |
         {count, plural,
             =2 {På två platser}

--- a/locale/misc/en.yaml
+++ b/locale/misc/en.yaml
@@ -6,8 +6,8 @@ callLog:
         status1: 'We reached {target}.'
         status11: '{target} did not pick up.'
         status12: Line busy.
-        status13: '{target} asked us to call back.'
-        status14: '{target} was not available.'
+        status13: '{target} asked us to call after {date}.'
+        status14: '{target} was not available. Call back after {date}'
         status15: We left a message.
         status21: We had the wrong number.
         status22: The call was dropped.

--- a/locale/misc/sv.yaml
+++ b/locale/misc/sv.yaml
@@ -6,8 +6,8 @@ callLog:
         status1: 'Vi nådde {target}.'
         status11: '{target} svarade inte.'
         status12: Linjen var upptagen.
-        status13: '{target} bad oss ringa tillbaka.'
-        status14: '{target} var inte tillgänglig just nu.'
+        status13: '{target} bad oss ringa efter {date}.'
+        status14: '{target} var inte tillgänglig. Ring efter {date}.'
         status15: Vi lämnade meddelande på telefonsvarare.
         status21: Vi hade fel nummer.
         status22: Samtalet bröts.

--- a/locale/report/steps/en.yaml
+++ b/locale/report/steps/en.yaml
@@ -66,6 +66,8 @@ organizerLog:
     summary:
         emptyLog: You did not leave a message to the official.
         leftLog: You left a message to the official.
+    templates:
+        wrongNumber: Wrong number, please investigate.
 successCouldTalk:
     effect:
         callBack: Future callers will see that we had to call back.

--- a/locale/report/steps/en.yaml
+++ b/locale/report/steps/en.yaml
@@ -14,6 +14,7 @@ callBack:
         oneWeek: We will call back no sooner than a week from now.
         twoWeeks: We will call back no sooner than two weeks from now.
 callerLog:
+    disabled: Notes have been disabled for this assignment.
     effect:
         leftLog: 'Future callers will see your note:'
     options:

--- a/locale/report/steps/en.yaml
+++ b/locale/report/steps/en.yaml
@@ -67,7 +67,7 @@ organizerLog:
         emptyLog: You did not leave a message to the official.
         leftLog: You left a message to the official.
     templates:
-        wrongNumber: Wrong number, please investigate.
+        wrongNumber: 'Wrong number ({ numbers }), please investigate.'
 successCouldTalk:
     effect:
         callBack: Future callers will see that we had to call back.
@@ -101,3 +101,11 @@ summary:
             =1 {one survey} other {# surveys}}.
         surveyDiscarded: Discarded responses for "{survey}"
         surveySubmitted: Submitted responses to "{survey}"
+wrongNumber:
+    options:
+        both: 'Both numbers were wrong'
+        single: 'Just { phone } was wrong'
+    question: 'Which number was wrong?'
+    summary:
+        both: 'Both numbers were wrong'
+        single: '{ phone } was the wrong number'

--- a/locale/report/steps/en.yaml
+++ b/locale/report/steps/en.yaml
@@ -2,17 +2,17 @@ callBack:
     effect:
         asap: '{target} is placed last in the queue'
         other: 'In the meantime, {target} is automatically removed from the queue.'
-    options:
-        asap: As soon as possible
-        fewDays: A few days from now
-        oneWeek: A week from now
-        twoWeeks: A few weeks from now
+    examples:
+        nextWeek: Next week
+        today: Later today
+        tomorrow: Tomorrow
+    examplesLabel: Examples
     question: When should we call back?
-    summary:
-        asap: We will call back as soon as possible.
-        fewDays: We will call back no sooner than a few days from now.
-        oneWeek: We will call back no sooner than a week from now.
-        twoWeeks: We will call back no sooner than two weeks from now.
+    submitButton: Call back after { date }
+    summary: We will call back after { date }
+    timeOfDay:
+        any: At any time of day
+        after: After { hour }:00
 callerLog:
     disabled: Notes have been disabled for this assignment.
     effect:

--- a/locale/report/steps/sv.yaml
+++ b/locale/report/steps/sv.yaml
@@ -66,6 +66,8 @@ organizerLog:
     summary:
         emptyLog: Du skrev ingen anteckning till organisatören.
         leftLog: Du skrev en anteckning till organisatören.
+    templates:
+        wrongNumber: Fel nummer, undersök gärna.
 successCouldTalk:
     effect:
         callBack: Framtida ringare kommer se att vi behövde ringa tillbaka.

--- a/locale/report/steps/sv.yaml
+++ b/locale/report/steps/sv.yaml
@@ -14,6 +14,7 @@ callBack:
         oneWeek: Vi ringer tillbaka tidigast om en vecka
         twoWeeks: Vi ringer tillbaka tidigast om två veckor
 callerLog:
+    disabled: Anteckningar är avstängda i det här ringuppdraget.
     effect:
         leftLog: 'Framtida ringare kommer att se din anteckning:'
     options:

--- a/locale/report/steps/sv.yaml
+++ b/locale/report/steps/sv.yaml
@@ -2,17 +2,17 @@ callBack:
     effect:
         asap: '{target} placeras sist i ringkön.'
         other: '{target} plockas automatiskt bort ur ringkön så länge.'
-    options:
-        asap: Så snart som möjligt
-        fewDays: Om ett par dagar
-        oneWeek: Om en vecka
-        twoWeeks: Om ett par veckor
+    examples:
+        nextWeek: Nästa vecka
+        today: Senare idag
+        tomorrow: I morgon
+    examplesLabel: Exempel
     question: När ska vi ringa tillbaka?
-    summary:
-        asap: Vi ringer tillbaka så snart som möjligt
-        fewDays: Vi ringer tillbaka tidigast om ett par dagar
-        oneWeek: Vi ringer tillbaka tidigast om en vecka
-        twoWeeks: Vi ringer tillbaka tidigast om två veckor
+    submitButton: Ring tidigast { date }
+    summary: Vi ringer tillbaka tidigast { date }
+    timeOfDay:
+        any: När som helst på dagen
+        after: Tidigast { hour }:00
 callerLog:
     disabled: Anteckningar är avstängda i det här ringuppdraget.
     effect:

--- a/locale/report/steps/sv.yaml
+++ b/locale/report/steps/sv.yaml
@@ -67,7 +67,7 @@ organizerLog:
         emptyLog: Du skrev ingen anteckning till organisatören.
         leftLog: Du skrev en anteckning till organisatören.
     templates:
-        wrongNumber: Fel nummer, undersök gärna.
+        wrongNumber: 'Fel nummer ({ numbers }), undersök gärna.'
 successCouldTalk:
     effect:
         callBack: Framtida ringare kommer se att vi behövde ringa tillbaka.
@@ -101,3 +101,11 @@ summary:
             =1 {en enkät} other {# enkäter}}.
         surveyDiscarded: Ignorerade svar på "{survey}"
         surveySubmitted: Skickade in svar på "{survey}"
+wrongNumber:
+    options:
+        both: 'Båda numren var fel'
+        single: 'Bara { phone } var fel'
+    question: 'Vilket nummer var fel?'
+    summary:
+        both: 'Båda numren var fel'
+        single: '{ phone } var fel nummer'

--- a/src/actions/call.js
+++ b/src/actions/call.js
@@ -155,46 +155,12 @@ export function submitCallReport() {
             else {
                 // Failed, call_back_after set
                 data.state = 13;
-
-                let date = new Date();
-                date.setUTC(true);
-
-                // Fast forward CBA date if not "ASAP"
-                switch (report.get('callBackAfter')) {
-                    case 'fewDays':
-                        date.advance('2 days');
-                        break;
-                    case 'oneWeek':
-                        date.advance('7 days');
-                        break;
-                    case 'twoWeeks':
-                        date.advance('14 days');
-                        break;
-                }
-
-                data.call_back_after = date.iso();
+                data.call_back_after = report.get('callBackAfter').iso();
             }
         }
         else if (report.get('failureReason') == 'notAvailable') {
             data.state = 14;
-
-            let date = new Date();
-            date.setUTC(true);
-
-            switch (report.get('callBackAfter')) {
-                case 'fewDays':
-                    date.advance('2 days');
-                    data.call_back_after = date.iso();
-                    break;
-                case 'oneWeek':
-                    date.advance('7 days');
-                    data.call_back_after = date.iso();
-                    break;
-                case 'twoWeeks':
-                    date.advance('14 days');
-                    data.call_back_after = date.iso();
-                    break;
-            }
+            data.call_back_after = report.get('callBackAfter').iso();
         }
         else if (report.get('leftMessage')) {
             data.state = 15;

--- a/src/actions/lane.js
+++ b/src/actions/lane.js
@@ -1,12 +1,17 @@
 import * as types from '.';
 import { laneByCallId } from '../store/lanes';
+import { selectedAssignment } from '../store/assignments';
 
 
 export function setLaneStep(lane, step) {
-    return {
-        type: types.SET_LANE_STEP,
-        payload: { lane, step },
-    };
+    return ({ dispatch, getState }) => {
+        let assignment = selectedAssignment(getState());
+
+        dispatch({
+            type: types.SET_LANE_STEP,
+            payload: { lane, step, assignment },
+        });
+    }
 }
 
 export function setLaneInfoMode(mode) {

--- a/src/components/misc/callLog/CallLogItem.jsx
+++ b/src/components/misc/callLog/CallLogItem.jsx
@@ -1,9 +1,10 @@
 import React from 'react';
 import ReactDOM from 'react-dom';
-import { FormattedDate, FormattedMessage as Msg } from 'react-intl';
+import { injectIntl, FormattedDate, FormattedMessage as Msg } from 'react-intl';
 import cx from 'classnames';
 
 
+@injectIntl
 export default class CallLogItem extends React.Component {
     constructor(props) {
         super(props);
@@ -33,6 +34,12 @@ export default class CallLogItem extends React.Component {
             caller: call.getIn(['caller', 'name']),
             target: call.getIn(['target', 'name']),
         };
+
+        const cba = call.get('call_back_after');
+        if (cba) {
+            const cbaDate = Date.create(cba);
+            summaryValues.date = this.props.intl.formatDate(cbaDate);
+        }
 
         let classes = cx('CallLogItem', 'status' + state, {
             contracted: this.state.viewMode === 'contracted',
@@ -71,6 +78,9 @@ export default class CallLogItem extends React.Component {
                         hour="2-digit"
                         minute="2-digit"
                         />
+                    <span className="CallLogItem-caller">
+                        { call.getIn(['caller', 'name']) }
+                    </span>
                 </div>
                 <div className="CallLogItem-summary">
                     <Msg id={ summaryMsg }
@@ -82,8 +92,6 @@ export default class CallLogItem extends React.Component {
                     { notes }
                 </div>
                 { expandButton }
-                <div className="CallLogItem-caller">
-                    { call.getIn(['caller', 'name']) }</div>
             </div>
         );
     }

--- a/src/components/misc/callLog/CallLogItem.scss
+++ b/src/components/misc/callLog/CallLogItem.scss
@@ -11,7 +11,7 @@
     }
 
     .CallLogItem-status {
-        width: 10em;
+        width: 6em;
         position: relative;
         padding: 0.6em 0 0.6em 1.5em;
         font-size: 0.8em;
@@ -20,9 +20,9 @@
         span {
             position: relative;
             display: inline-block;
-            width: 48%;
+            width: 46%;
             height: 0.1em;
-            margin: 0 2% 0 0;
+            margin: 0 4% 0 0;
             background-color: lighten($c-ui-dark, 20%);
             vertical-align: middle;
 
@@ -171,11 +171,9 @@
 }
 
 .CallLogItem-caller {
-    font-size: 0.7em;
-    position: absolute;
-    right: 0.5em;
-    top: 3em;
-    color: lighten($c-text, 10);
+    &:before {
+        content: ", ";
+    }
 }
 
 .CallLogItem-notes {

--- a/src/components/report/ReportForm.jsx
+++ b/src/components/report/ReportForm.jsx
@@ -53,5 +53,6 @@ const componentFromStep = step => {
         caller_log: steps.CallerLogStep,
         organizer_log: steps.OrganizerLogStep,
         summary: steps.SummaryStep,
+        wrong_number: steps.WrongNumberStep,
     }[step];
 };

--- a/src/components/report/steps/CallBackStep.jsx
+++ b/src/components/report/steps/CallBackStep.jsx
@@ -1,12 +1,22 @@
 import React from 'react';
-import { FormattedMessage as Msg } from 'react-intl';
+import { injectIntl, FormattedMessage as Msg } from 'react-intl';
 
 import Button from '../../../common/misc/Button';
 import ReportStepBase from './ReportStepBase';
 import { setCallReportField } from '../../../actions/call';
 
 
+@injectIntl
 export default class CallBackStep extends ReportStepBase {
+    constructor(props) {
+        super(props);
+
+        this.state = Object.assign({}, this.state, {
+            selectedDate: Date.create('tomorrow'),
+            selectedHour: 0,
+        });
+    }
+
     getRenderMode(report) {
         if (report.get('success') && report.get('targetCouldTalk')) {
             // Don't render this step for successfull calls where
@@ -26,30 +36,81 @@ export default class CallBackStep extends ReportStepBase {
     }
 
     renderForm(report) {
+        const optionElems = [];
+        for (let h = 0; h < 24; h++) {
+            const hStr = ('0' + h).slice(-2);
+            const label = (h == 0)?
+                this.props.intl.formatMessage(
+                    { id: 'report.steps.callBack.timeOfDay.any' }) :
+                this.props.intl.formatMessage(
+                    { id: 'report.steps.callBack.timeOfDay.after' },
+                    { hour: hStr });
+
+            optionElems.push(
+                <option key={ h } value={ h }>{ label }</option>
+            );
+        }
+
+        const date = this.dateFromState();
+        const dateStr = this.props.intl.formatDate(date, {
+            month: 'short',
+            year: 'numeric',
+            day: 'numeric',
+            hour: date.getHours()? 'numeric' : undefined,
+            minute: date.getHours()? 'numeric' : undefined,
+        });
+
         return [
             <Msg key="question" tagName="p"
                 id="report.steps.callBack.question"/>,
-            <Button key="noResponseButton"
-                labelMsg="report.steps.callBack.options.asap"
-                onClick={ this.onClickOption.bind(this, 'asap') }/>,
-            <Button key="otherPersonButton"
-                labelMsg="report.steps.callBack.options.fewDays"
-                onClick={ this.onClickOption.bind(this, 'fewDays') }/>,
-            <Button key="wrongNumberButton"
-                labelMsg="report.steps.callBack.options.oneWeek"
-                onClick={ this.onClickOption.bind(this, 'oneWeek') }/>,
-            <Button key="lineBusyButton"
-                labelMsg="report.steps.callBack.options.twoWeeks"
-                onClick={ this.onClickOption.bind(this, 'twoWeeks') }/>,
+            <div key="dateTime" className="CallBackStep-dateTime">
+                <input type="date"
+                    onChange={ this.onDateChange.bind(this) }
+                    value={ this.state.selectedDate.format('{yyyy}-{MM}-{dd}') }/>
+
+                <select
+                    onChange={ this.onHourChange.bind(this) }
+                    value={ this.state.selectedHour }>
+                    { optionElems }
+                </select>
+
+                <div className="CallBackStep-examples">
+                    <Msg id="report.steps.callBack.examplesLabel"/>:
+
+                    <a
+                        onClick={ this.onExampleClick.bind(this, 'today') }>
+                        <Msg id="report.steps.callBack.examples.today"/>
+                    </a>,
+                    <a
+                        onClick={ this.onExampleClick.bind(this, 'tomorrow') }>
+                        <Msg id="report.steps.callBack.examples.tomorrow"/>
+                    </a>,
+                    <a
+                        onClick={ this.onExampleClick.bind(this, 'nextWeek') }>
+                        <Msg id="report.steps.callBack.examples.nextWeek"/>
+                    </a>
+                </div>
+            </div>,
+            <Button key="submitButton"
+                labelMsg="report.steps.callBack.submitButton"
+                labelValues={{ date: dateStr }}
+                onClick={ this.onSubmitClick.bind(this) }/>,
         ];
     }
 
     renderSummary(report) {
-        let cba = report.get('callBackAfter');
-        let msgId = 'report.steps.callBack.summary.' + cba;
+        const date = report.get('callBackAfter');
+        const dateStr = this.props.intl.formatDate(date, {
+            month: 'short',
+            year: 'numeric',
+            day: 'numeric',
+            hour: date.getHours()? 'numeric' : undefined,
+            minute: date.getHours()? 'numeric' : undefined,
+        });
 
         return (
-            <Msg tagName="p" id={ msgId }/>
+            <Msg tagName="p" id="report.steps.callBack.summary"
+                values={{ date: dateStr }}/>
         );
     }
 
@@ -64,8 +125,54 @@ export default class CallBackStep extends ReportStepBase {
         );
     }
 
-    onClickOption(option) {
+    onHourChange(ev) {
+        this.setState({
+            selectedHour: parseInt(ev.target.value) || 0,
+        });
+    }
+
+    onDateChange(ev) {
+        this.setState({
+            selectedDate: Date.create(ev.target.value),
+        });
+    }
+
+    onExampleClick(ex) {
+        if (ex == 'today') {
+            const today = new Date();
+            this.setState({
+                selectedDate: today,
+                selectedHour: Math.min(23, today.getHours() + 3),
+            });
+        }
+        else if (ex == 'tomorrow') {
+            this.setState({
+                selectedDate: Date.create('tomorrow'),
+                selectedHour: 0,
+            });
+        }
+        else if (ex == 'nextWeek') {
+            this.setState({
+                selectedDate: Date.create('next monday'),
+                selectedHour: 0,
+            });
+        }
+    }
+
+    onSubmitClick() {
+        const date = this.dateFromState();
+
         this.props.dispatch(setCallReportField(
-            this.props.call, 'callBackAfter', option));
+            this.props.call, 'callBackAfter', date));
+    }
+
+    dateFromState() {
+        const date = Date.create(this.state.selectedDate);
+
+        date.setHours(this.state.selectedHour);
+        date.setMinutes(0);
+        date.setSeconds(0);
+
+        return date;
     }
 }

--- a/src/components/report/steps/CallBackStep.scss
+++ b/src/components/report/steps/CallBackStep.scss
@@ -1,0 +1,33 @@
+.CallBackStep {
+    input[type=date], select {
+        display: block;
+        margin: 0 0 0.5em;
+        width: 100%;
+        font-size: 1em;
+        text-align: center;
+        font-family: franklin-gothic-urw, sans-serif;
+
+        @include medium-screen {
+            width: 46%;
+        }
+    }
+}
+
+.CallBackStep-examples {
+    margin: 0.2em 0 2em;
+    font-size: 0.6em;
+
+    color: $c-ui-dark;
+
+    a {
+        display: inline-block;
+        margin-left: 0.4em;
+        cursor: pointer;
+        color: inherit;
+        text-decoration: underline;
+
+        &:hover {
+            color: darken($c-ui-darker, 15);
+        }
+    }
+}

--- a/src/components/report/steps/CallerLogStep.jsx
+++ b/src/components/report/steps/CallerLogStep.jsx
@@ -12,8 +12,10 @@ import {
 export default class CallerLogStep extends ReportStepBase {
     componentDidMount() {
         // Skip this step if caller notes are disabled
-        if (this.props.report.get('disableCallerNotes')) {
-            this.props.dispatch(finishCallReport(this.props.call));
+        if (this.props.report.get('step') == 'caller_log') {
+            if (this.props.report.get('disableCallerNotes')) {
+                this.props.dispatch(finishCallReport(this.props.call));
+            }
         }
     }
 

--- a/src/components/report/steps/CallerLogStep.jsx
+++ b/src/components/report/steps/CallerLogStep.jsx
@@ -10,6 +10,13 @@ import {
 
 
 export default class CallerLogStep extends ReportStepBase {
+    componentDidMount() {
+        // Skip this step if caller notes are disabled
+        if (this.props.report.get('disableCallerNotes')) {
+            this.props.dispatch(finishCallReport(this.props.call));
+        }
+    }
+
     getRenderMode(report) {
         return (report.get('step') === 'caller_log')?
             'form' : 'summary';
@@ -21,11 +28,22 @@ export default class CallerLogStep extends ReportStepBase {
             'report.steps.callerLog.options.saveWithLog' :
             'report.steps.callerLog.options.saveWithoutLog';
 
+        let input = (
+            <textarea key="message" value={ report.get('callerLog') }
+                onChange={ this.onChangeMessage.bind(this) }/>
+        );
+
+        if (report.get('disableCallerNotes')) {
+            input = (
+                <Msg key="disabled" tagName="small"
+                    id="report.steps.callerLog.disabled"/>
+            );
+        }
+
         return [
             <Msg key="question" tagName="p"
                 id="report.steps.callerLog.question"/>,
-            <textarea key="message" value={ report.get('callerLog') }
-                onChange={ this.onChangeMessage.bind(this) }/>,
+            input,
             <Button key="saveButton"
                 labelMsg={ saveLabelMsg }
                 onClick={ this.onClickSave.bind(this) }/>,
@@ -50,7 +68,14 @@ export default class CallerLogStep extends ReportStepBase {
 
     renderEffect(report) {
         let log = report.get('callerLog') || '';
-        if (log.length) {
+
+        if (report.get('disableCallerNotes')) {
+            return [
+                <Msg key="disabled" tagName="p"
+                    id="report.steps.callerLog.disabled"/>,
+            ];
+        }
+        else if (log.length) {
             return [
                 <Msg key="effect" tagName="p"
                     id="report.steps.callerLog.effect.leftLog"/>,

--- a/src/components/report/steps/OrganizerLogStep.jsx
+++ b/src/components/report/steps/OrganizerLogStep.jsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { FormattedMessage as Msg } from 'react-intl';
+import { injectIntl, FormattedMessage as Msg } from 'react-intl';
 
 import Button from '../../../common/misc/Button';
 import ReportStepBase from './ReportStepBase';
@@ -9,7 +9,24 @@ import {
 } from '../../../actions/call';
 
 
+@injectIntl
 export default class OrganizerLogStep extends ReportStepBase {
+    componentDidMount() {
+        const report = this.props.report;
+
+        // If wrong number was reported, and there isn't already
+        // an organizer log message, note it here
+        if (!report.get('organizerLog') && !report.get('success')
+            && report.get('failureReason') == 'wrongNumber') {
+
+            const msg = this.props.intl.formatMessage(
+                { id: 'report.steps.organizerLog.templates.wrongNumber' });
+
+            this.props.dispatch(setOrganizerLogMessage(
+                this.props.call, msg));
+        }
+    }
+
     getRenderMode(report) {
         if (report.get('organizerActionNeeded')) {
             return (report.get('step') === 'organizer_log')?

--- a/src/components/report/steps/OrganizerLogStep.jsx
+++ b/src/components/report/steps/OrganizerLogStep.jsx
@@ -13,14 +13,25 @@ import {
 export default class OrganizerLogStep extends ReportStepBase {
     componentDidMount() {
         const report = this.props.report;
+        const target = this.props.target;
 
         // If wrong number was reported, and there isn't already
         // an organizer log message, note it here
         if (!report.get('organizerLog') && !report.get('success')
             && report.get('failureReason') == 'wrongNumber') {
 
+            const wrongNumber = report.get('wrongNumber');
+            let numbers = [];
+            if (wrongNumber == 'both' || wrongNumber == 'phone') {
+                numbers.push(target.get('phone'));
+            }
+            if (wrongNumber == 'both' || wrongNumber == 'altPhone') {
+                numbers.push(target.get('alt_phone'));
+            }
+
             const msg = this.props.intl.formatMessage(
-                { id: 'report.steps.organizerLog.templates.wrongNumber' });
+                { id: 'report.steps.organizerLog.templates.wrongNumber' },
+                { numbers: numbers.join(', ') });
 
             this.props.dispatch(setOrganizerLogMessage(
                 this.props.call, msg));

--- a/src/components/report/steps/ReportStepBase.scss
+++ b/src/components/report/steps/ReportStepBase.scss
@@ -66,6 +66,14 @@
             }
         }
 
+        small {
+            display: block;
+            font-size: 0.8em;
+            font-style: italic;
+            color: lighten($c-text, 40);
+            margin: 0 0 1.4em 1.8em;
+        }
+
         .Button {
             @include button(#f9f9f9);
             display: block;

--- a/src/components/report/steps/WrongNumberStep.jsx
+++ b/src/components/report/steps/WrongNumberStep.jsx
@@ -9,12 +9,14 @@ import { setLaneStep } from '../../../actions/lane';
 
 export default class WrongNumberStep extends ReportStepBase {
     componentDidMount() {
-        // Skip this step if there is just one number
-        const target = this.props.target;
-        if (!target.get('phone') || !target.get('alt_phone')) {
-            this.props.dispatch(setCallReportField(
-                this.props.call, 'wrongNumber',
-                target.get('phone')? 'phone' : 'alt_phone'));
+        if (this.props.report.get('step') == 'wrong_number') {
+            // Skip this step if there is just one number
+            const target = this.props.target;
+            if (!target.get('phone') || !target.get('alt_phone')) {
+                this.props.dispatch(setCallReportField(
+                    this.props.call, 'wrongNumber',
+                    target.get('phone')? 'phone' : 'alt_phone'));
+            }
         }
     }
 

--- a/src/components/report/steps/WrongNumberStep.jsx
+++ b/src/components/report/steps/WrongNumberStep.jsx
@@ -1,0 +1,87 @@
+import React from 'react';
+import { FormattedMessage as Msg } from 'react-intl';
+
+import Button from '../../../common/misc/Button';
+import ReportStepBase from './ReportStepBase';
+import { setCallReportField } from '../../../actions/call';
+import { setLaneStep } from '../../../actions/lane';
+
+
+export default class WrongNumberStep extends ReportStepBase {
+    componentDidMount() {
+        // Skip this step if there is just one number
+        const target = this.props.target;
+        if (!target.get('phone') || !target.get('alt_phone')) {
+            this.props.dispatch(setCallReportField(
+                this.props.call, 'wrongNumber',
+                target.get('phone')? 'phone' : 'alt_phone'));
+        }
+    }
+
+    getRenderMode(report) {
+        if (report.get('success')) {
+            // Don't render this step at all if the call was successful.
+            return 'none';
+        }
+        else if (report.get('failureReason') !== 'wrongNumber') {
+            // Don't render this if failure was anything but wrong number.
+            return 'none';
+        }
+        else {
+            const target = this.props.target;
+            if (target.get('phone') && target.get('alt_phone')) {
+                return (report.get('step') === 'wrong_number')?
+                    'form' : 'summary';
+            }
+            else {
+                // Don't render this when there is only one number
+                return 'none';
+            }
+        }
+    }
+
+    renderForm(report) {
+        const target = this.props.target;
+
+        return [
+            <Msg key="question" tagName="p"
+                id="report.steps.wrongNumber.question"/>,
+            <Button key="phoneButton"
+                labelMsg="report.steps.wrongNumber.options.single"
+                labelValues={{ phone: target.get('phone') }}
+                onClick={ this.onClickOption.bind(this, 'phone') }/>,
+            <Button key="altPhoneButton"
+                labelMsg="report.steps.wrongNumber.options.single"
+                labelValues={{ phone: target.get('alt_phone') }}
+                labelMsg="report.steps.wrongNumber.options.single"
+                onClick={ this.onClickOption.bind(this, 'altPhone') }/>,
+            <Button key="bothButton"
+                labelMsg="report.steps.wrongNumber.options.both"
+                onClick={ this.onClickOption.bind(this, 'both') }/>,
+        ];
+    }
+
+    renderSummary(report) {
+        const option = report.get('wrongNumber');
+        const target = this.props.target;
+
+        let msgValues;
+        let msgId = 'report.steps.wrongNumber.summary.both';
+        if (option != 'both') {
+            msgId = 'report.steps.wrongNumber.summary.single';
+            msgValues = {
+                phone: (option == 'phone') ?
+                    target.get('phone') : target.get('alt_phone'),
+            };
+        }
+
+        return (
+            <Msg tagName="p" id={ msgId } values={ msgValues }/>
+        );
+    }
+
+    onClickOption(option) {
+        this.props.dispatch(setCallReportField(
+            this.props.call, 'wrongNumber', option));
+    }
+}

--- a/src/components/report/steps/index.js
+++ b/src/components/report/steps/index.js
@@ -7,3 +7,4 @@ export CallerLogStep from './CallerLogStep';
 export OrganizerActionStep from './OrganizerActionStep';
 export OrganizerLogStep from './OrganizerLogStep';
 export SummaryStep from './SummaryStep';
+export WrongNumberStep from './WrongNumberStep';

--- a/src/store/calls.js
+++ b/src/store/calls.js
@@ -42,6 +42,7 @@ export const REPORT_STEPS = [
     'success_or_failure',
     'success_could_talk',
     'failure_reason',
+    'wrong_number',
     'failure_message',
     'call_back',
     'organizer_action',
@@ -198,6 +199,7 @@ export default createReducer(initialState, {
                     targetCouldTalk: false,
                     callBackAfter: null,
                     failureReason: null,
+                    wrongNumber: null,
                     leftMessage: false,
                     callerLog: '',
                     organizerActionNeeded: false,
@@ -238,13 +240,16 @@ export default createReducer(initialState, {
                 nextStep = 'call_back';
             }
             else if (value === 'wrongNumber') {
-                nextStep = 'organizer_log';
+                nextStep = 'wrong_number';
                 state = state.updateIn(['reports', callId], report => report
                     .set('organizerActionNeeded', true));
             }
             else {
                 nextStep = 'organizer_action';
             }
+        }
+        else if (field === 'wrongNumber') {
+            nextStep = 'organizer_log';
         }
         else if (field === 'leftMessage') {
             nextStep = 'organizer_action';

--- a/src/store/calls.js
+++ b/src/store/calls.js
@@ -230,14 +230,21 @@ export default createReducer(initialState, {
         else if (field === 'success') {
             nextStep = 'failure_reason';
         }
-        else if (field === 'failureReason' && value === "noPickup") {
-            nextStep = 'failure_message';
-        }
-        else if (field === 'failureReason' && value === "notAvailable") {
-            nextStep = 'call_back';
-        }
         else if (field === 'failureReason') {
-            nextStep = 'organizer_action';
+            if (value === "noPickup") {
+                nextStep = 'failure_message';
+            }
+            else if (value === "notAvailable") {
+                nextStep = 'call_back';
+            }
+            else if (value === 'wrongNumber') {
+                nextStep = 'organizer_log';
+                state = state.updateIn(['reports', callId], report => report
+                    .set('organizerActionNeeded', true));
+            }
+            else {
+                nextStep = 'organizer_action';
+            }
         }
         else if (field === 'leftMessage') {
             nextStep = 'organizer_action';

--- a/src/store/calls.js
+++ b/src/store/calls.js
@@ -189,6 +189,8 @@ export default createReducer(initialState, {
         // Create an empty report for current call when navigating
         // to the "call" lane step, if there is none already.
         if (step === 'call' && !report) {
+            const assignment = action.payload.assignment;
+
             return state
                 .setIn(['reports', callId], immutable.fromJS({
                     step: REPORT_STEPS[0],
@@ -200,6 +202,7 @@ export default createReducer(initialState, {
                     callerLog: '',
                     organizerActionNeeded: false,
                     organizerLog: '',
+                    disableCallerNotes: assignment.get('disable_caller_notes'),
                 }));
         }
         else {


### PR DESCRIPTION
This PR contains a bunch of small new UI features that line up with new features in the Zetkin Platform:

* Handle `Assignment.disable_caller_notes` (#193)
* Specify which number was wrong in report (#187)
* Add time of day to `call_back_after` (#207)

It also makes some minor improvements more or less related to these new features:

* Automatically set `organizer_action_needed` and `message_to_organizer` using a templated message when the number was wrong (#188)
* Tweak `CampaignForm` texts that were either misleading or did not fit the mobile interface (#195)

## In-depth: Reporting wrong numbers
Reporting wrong numbers now work like this:

![wrongnumberreport](https://user-images.githubusercontent.com/550212/42992812-f4a446be-8c09-11e8-95a7-210051a3646c.gif)