### PR TITLE
fix: updates settings for running as standalone

### DIFF
--- a/bin/run_dev
+++ b/bin/run_dev
@@ -7,9 +7,10 @@ docker run \
     -v $PWD/src:/var/app/src \
     --name call_zetk_in \
     --env TOKEN_SECRET=012345678901234567890123 \
+    --env ZETKIN_USE_TLS=0 \
     --env ZETKIN_LOGIN_URL=http://login.dev.zetkin.org \
-    --env ZETKIN_APP_ID=514d9750b6f242c2a7abc31f6fc17a73 \
-    --env ZETKIN_APP_KEY=NjcwOWU0ZDktOGVmYi00N2ViLTk1MTEtY2UyYjY0ODU5YWU4 \
+    --env ZETKIN_APP_ID=59dda3d6e4f2437db756395b54c733aa \
+    --env ZETKIN_APP_KEY=ZWUwNzMxNGYtYTMwZC00YjE1LWI5ZmEtNjlkY2UwYzYxOGY4 \
     --env ZETKIN_DOMAIN=dev.zetkin.org \
     -p 80:80 \
     -p 81:81 \

--- a/src/server/app.js
+++ b/src/server/app.js
@@ -58,6 +58,7 @@ export default function initApp(messages) {
                 hostname: req.hostname,
                 port: process.env.WEBPACK_PORT || 81,
                 pathname: '/static/main.js',
+                protocol: 'http'
             });
 
             res.redirect(303, wpMainJs);


### PR DESCRIPTION
* ZETKIN_APP_ID and ZETKIN_APP_KEY values are no longer valid (fixed by updating values in ./bin/run_dev)
* It's trying to reach online development services with https that needs to be reached with http (fixed by adding --env ZETKIN_USE_TLS=0 \ in ./bin/run_dev)
* Missing protocol for main.js redirect (fixed by adding protocol: 'http' around line 60 in server/app.js)