### PR TITLE
External dialling

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
   "dependencies": {
     "animated-scrollto": "^1.1.0",
     "array.prototype.find": "^2.0.0",
+    "axios": "^0.27.2",
     "babel-loader": "^6.2.10",
     "babel-plugin-transform-decorators-legacy": "^1.3.4",
     "babel-preset-env": "^1.1.8",

--- a/src/actions/user.js
+++ b/src/actions/user.js
@@ -6,7 +6,25 @@ export function retrieveUserMemberships() {
         dispatch({
             type: types.RETRIEVE_USER_MEMBERSHIPS,
             payload: {
-                promise: z.resource('users', 'me', 'memberships').get()
+                promise: z.resource('users', 'me', 'memberships')
+                    .get()
+                    .then(res => {
+                        return Promise.all(res.data.data.map(membership => Promise.resolve(membership)
+                            .then(membership => {
+                                return z.resource('orgs', membership.organization.id, 'people', membership.profile.id)
+                                    .get()
+                                    .then(profileRes => {
+                                        const profileData = profileRes.data.data;
+                                        // Look for special custom fields for telavox user credentials to assess
+                                        // whether to use VoIP for this caller profile.
+                                        membership.profile.has_voip_credentials = (
+                                            !!profileData.telavox_username && !!profileData.telavox_password
+                                        );
+                                    });
+                            })
+                        ))
+                        .then(() => res);
+                    })
             }
         });
     };

--- a/src/components/call/TargetInfo.jsx
+++ b/src/components/call/TargetInfo.jsx
@@ -25,7 +25,7 @@ export default class TargetInfo extends React.Component {
     };
 
     render() {
-        let target = this.props.target;
+        const { caller, target } = this.props;
         let callInfo, tagList;
 
         if (this.props.showFullInfo) {
@@ -59,11 +59,31 @@ export default class TargetInfo extends React.Component {
                 );
             }
 
-            callInfo = targetUtils.getNumbers(target).map(num => (
-                <span key={num} className="TargetInfo-number">
-                    <a href={ 'tel:' + num }>{ num }</a>
-                </span>
-            )).concat([
+            callInfo = targetUtils.getNumbers(target).map(num => {
+                let onClick = null;
+                if (caller.get('has_voip_credentials')) {
+                    onClick = ev => {
+                        ev.preventDefault();
+                        fetch('/api/dial', {
+                            method: 'POST',
+                            headers: {
+                                'Content-Type': 'application/json',
+                            },
+                            body: JSON.stringify({
+                                number: num,
+                                caller: caller.get('id'),
+                            }),
+                        });
+                        return false;
+                    };
+                }
+
+                return (
+                    <span key={num} className="TargetInfo-number">
+                        <a href={ 'tel:' + num } onClick={onClick}>{ num }</a>
+                    </span>
+                );
+            }).concat([
                 <div key="lastCall" className="TargetInfo-lastCall">
                     { lastCallLabel }
                 </div>

--- a/src/components/call/TargetInfo.jsx
+++ b/src/components/call/TargetInfo.jsx
@@ -9,14 +9,17 @@ import * as targetUtils from "../../utils/target";
 import { selectedAssignment } from '../../store/assignments';
 import Avatar from '../misc/Avatar';
 import TagList from '../misc/TagList';
+import { selectedAssignmentCallerProfile } from '../../store/user';
 
 const mapStateToProps = state => ({
     assignment: selectedAssignment(state),
+    caller: selectedAssignmentCallerProfile(state),
 });
 
 @connect(mapStateToProps)
 export default class TargetInfo extends React.Component {
     static propTypes = {
+        caller: PropTypes.map.isRequired,
         target: PropTypes.map.isRequired,
         showFullInfo: PropTypes.bool,
     };

--- a/src/store/index.js
+++ b/src/store/index.js
@@ -48,8 +48,8 @@ export const configureStore = (initialState, z) => {
     ];
 
     let devTools = f => f;
-    if (typeof window === 'object' && window.devToolsExtension) {
-        devTools = window.devToolsExtension({
+    if (typeof window === 'object' && window.__REDUX_DEVTOOLS_EXTENSION__) {
+        devTools = window.__REDUX_DEVTOOLS_EXTENSION__({
             deserializeState: state => immutable.fromJS(state)
         });
     }

--- a/src/store/user.js
+++ b/src/store/user.js
@@ -2,7 +2,20 @@ import { createReducer } from 'redux-create-reducer';
 import immutable from 'immutable';
 
 import * as types from '../actions';
+import { selectedAssignment } from './assignments';
 
+
+export const selectedAssignmentCallerProfile = state => {
+    const assignment = selectedAssignment(state);
+    if (assignment) {
+        const orgId = assignment.getIn(['organization', 'id']);
+        const profile = state.getIn(['user', 'membershipList', 'items', orgId.toString(), 'profile']);
+        return profile;
+    }
+    else {
+        return null;
+    }
+};
 
 const initialState = immutable.fromJS({
     isPending: false,


### PR DESCRIPTION
## Description
This PR implements external dialling using the Telavox web interface and API. It allows a caller to click a number to trigger a call via Telavox if the user's person profile has telavox credentials in "magically" named custom fields `telavox_username` and `telavox_password`.

## Screenshot
Note tab with Telavox dialling side by side with Zetkin tab.

<img width="1390" alt="image" src="https://user-images.githubusercontent.com/550212/175259805-0a5c128d-310b-4546-8a90-e91902d2326b.png">

## Note to reviewer
To test this:

1. Create custom fields `telavox_username` and `telavox_password`, both of types `text`. Add valid Telavox credentials to the caller's profile via Zetkin Organize.
2. Create a call assignment, and **importantly, only add targets with phone numbers you actually want to call**. I tend to just replace all phone numbers in the dummydata with my own.
3. Open app.telavox.com in a separate tab and log in with the credentials. Run the tabs side by side
4. In Zetkin Call, click the number of a target to trigger a dial (for the first call, you might have to manually navigate to the Telavox tab and accept the call)

## Related issues
Fixes #248 