### PR TITLE
Exclude signature from survey submissions if signature type is force_anonymous

### DIFF
--- a/src/actions/call.js
+++ b/src/actions/call.js
@@ -208,8 +208,15 @@ export function submitCallReport() {
                         return response;
                     });
 
+                    let signatureType = state.getIn(['surveys', 'surveyList', 'items', surveyId, 'signature']);
+
+                    let signature = null;
+                    if (signatureType != 'force_anonymous') {
+                        signature = call.getIn(['target', 'id']);
+                    }
+
                     let data = {
-                        signature: call.getIn(['target', 'id']),
+                        signature: signature,
                         responses: responses.toList().toJS(),
                     };
 


### PR DESCRIPTION
Do not include a survey response signature if survey signature type is force_anonymous

Resolves #249