### PR TITLE
Prepopulate person fields in surveys

### DIFF
--- a/src/actions/survey.js
+++ b/src/actions/survey.js
@@ -20,10 +20,11 @@ export function retrieveSurveys() {
 }
 
 export function retrieveSurvey(orgId, surveyId) {
-    return ({ dispatch, z }) => {
+    return ({ dispatch, getState, z }) => {
+        const call = currentCall(getState()).toJS();
         dispatch({
             type: types.RETRIEVE_SURVEY,
-            meta: { orgId, surveyId },
+            meta: { call, orgId, surveyId },
             payload: {
                 promise: z.resource('orgs', orgId,
                     'surveys', surveyId).get()


### PR DESCRIPTION
This PR adds logic to the store to prepopulate a survey with responses after loading it. It does so only the first time the user opens (and hence loads) a survey's elements during a call.

This PR also updates the version of zetkin-common to include changes that are being introduced in pending PR zetkin/zetkin-common#53.

## Things to test:

* Try stepping through a call without intracting with any surveys containing `person_field` questions (should work as before)
* Try stepping through a call and just open a survey with a `person_field`
  * Confirm that it shows the prepopulated value
  * Confirm that the report sees the survey, but excludes it by default
* Try interacting with a survey that contains a `person_field` during a call
  * Confirm that it shows the prepopulated value
  * Confirm that you can change the prepopulated value and it does not reset when closing/reopening the survey in the interface
  * Confirm that the report includes the survey
  * Confirm that survey is submitted correctly and contains the correct data (should be verified in Organize)