### PR TITLE
Change tutorial message for VoIP

### DIFF
--- a/locale/tutorial/da.yaml
+++ b/locale/tutorial/da.yaml
@@ -27,7 +27,7 @@ notes:
         p: >-
             Dette er den første person du skal ringe til. Forbered dig på
             samtalen, og fortsæt så for at lave opkaldet. God vind!
-    targetInfo:
+    targetInfoPhone:
         h: Brug din telefon
         href: 'http://manual.zetkin.org/dk'
         p: >-

--- a/locale/tutorial/en.yaml
+++ b/locale/tutorial/en.yaml
@@ -25,9 +25,16 @@ notes:
         p: >-
             This is the first person you will be calling. Prepare for the call
             and then continue to make the call.
-    targetInfo:
+    targetInfoPhone:
         h: Use your phone
         href: 'http://manual.zetkin.org/en'
         p: >-
             Here is a short summary of the person, including their phone number.
             Use a regular phone to dial and call the person.
+
+    targetInfoVoip:
+        h: Click phone number to use IP dialing
+        href: 'http://manual.zetkin.org/en'
+        p: >-
+            Here is a short summary of the person, including their phone number.
+            Click the number to dial or use a regular phone to dial the number.

--- a/locale/tutorial/nn.yaml
+++ b/locale/tutorial/nn.yaml
@@ -25,7 +25,7 @@ notes:
         p: >-
             Dette er den fyrste personen du ringer. Forbered deg fyrst og så
             hald fram med samtalen.
-    targetInfo:
+    targetInfoPhone:
         h: Bruk telefonen din
         href: 'http://manual.zetkin.org/no'
         p: >-

--- a/locale/tutorial/sv.yaml
+++ b/locale/tutorial/sv.yaml
@@ -29,10 +29,17 @@ notes:
         p: |-
             Här är den första personen du ska ringa. Förbered dig inför
             samtalet och gå sedan vidare för att ringa.
-    targetInfo:
+    targetInfoPhone:
         h: Använd din telefon
         href: >-
             http://manual.zetkin.org/sv/for-aktivister/ringa-med-zetkin/samtalet/ring/
         p: |-
             Här ser du en sammanfattning om personen, inklusive numret du ska
             ringa. För att ringa använder du en vanlig telefon.
+    targetInfoVoip:
+        h: Klicka på telefonnumret för att ringa med IP-telefoni
+        href: >-
+            http://manual.zetkin.org/sv/for-aktivister/ringa-med-zetkin/samtalet/ring/
+        p: |-
+            Här ser du en sammanfattning om personen, inklusive numret du ska
+            ringa. För att ringa klickar du på numret eller använder en vanlig telefon.

--- a/src/components/pages/CallPage.jsx
+++ b/src/components/pages/CallPage.jsx
@@ -8,10 +8,12 @@ import { selectedLane } from '../../store/lanes';
 import { pushTutorialNote } from '../../actions/tutorial';
 import ViewSize from "../misc/ViewSize";
 import getViewSize from '../../utils/getViewSize';
+import { selectedAssignmentCallerProfile } from '../../store/user';
 
 
 const mapStateToProps = state => ({
     calls: state.get('calls'),
+    caller: selectedAssignmentCallerProfile(state),
     lane: selectedLane(state),
 });
 
@@ -40,8 +42,12 @@ export default class CallPage extends React.Component {
                 else if (step == 'call') {
                     if (getViewSize() != 'small') {
                         // This tutorial step is redundant on mobile
+                        let tutorialMessage = 'tutorial.notes.targetInfoPhone';
+                        if (nextProps.caller.get('has_voip_credentials')) {
+                            tutorialMessage = 'tutorial.notes.targetInfoVoip';
+                        }
                         this.props.dispatch(pushTutorialNote(
-                            'tutorial.notes.targetInfo',
+                            tutorialMessage,
                             '.TargetInfo'));
                     }
 


### PR DESCRIPTION
Change tutorial message depending on whether the user is using IP telephony or not.

I decided not to be so vague and use different message depending on whether the caller `has_voip_credentials`

Resolves #253 