### PR TITLE
Survey sorting

### DIFF
--- a/locale/panes/da.yaml
+++ b/locale/panes/da.yaml
@@ -10,7 +10,7 @@ input:
                     other {# bookinger}
                 }
             h2: Aktuelle kampagner
-            respondButton: 'Meld dig til {kampagne}'
+            respondButton: 'Meld til'
             responses: |-
                 {numResponses, plural,
                     =0 {ingen tilmeldinger}
@@ -20,7 +20,7 @@ input:
             status: '{target} har'
         surveys:
             h2: Spørgeskemaer
-            respondButton: 'Svar på {survey}'
+            respondButton: 'Svar'
     summaryLabel: Resumé
     summaryLink: Resumé
 instructions:

--- a/locale/panes/en.yaml
+++ b/locale/panes/en.yaml
@@ -10,7 +10,7 @@ input:
                     other {# bookings}
                 }
             h2: Active campaigns
-            respondButton: 'Sign up for {campaign}'
+            respondButton: 'Sign up'
             responses: |-
                 {numResponses, plural,
                     =0 {no unbooked sign-ups}
@@ -20,7 +20,7 @@ input:
             status: '{target} has'
         surveys:
             h2: Surveys
-            respondButton: 'Respond to {survey}'
+            respondButton: 'Respond'
     summaryLabel: Summary
     summaryLink: Summary
 instructions:

--- a/locale/panes/nn.yaml
+++ b/locale/panes/nn.yaml
@@ -10,7 +10,7 @@ input:
                     other {# bestillingar}
                 }
             h2: Aktive kampanjar
-            respondButton: 'Skriv deg opp på {campaign}'
+            respondButton: 'Skriv opp'
             responses: |-
                 {numResponses, plural,
                     =0 {ingen utildelte oppmeldingar}
@@ -20,7 +20,7 @@ input:
             status: '{target} har'
         surveys:
             h2: Undersøkingar
-            respondButton: 'Svar på {survey}'
+            respondButton: 'Svar'
     summaryLabel: Oppsummering
     summaryLink: Oppsummering
 instructions:

--- a/locale/panes/sv.yaml
+++ b/locale/panes/sv.yaml
@@ -10,7 +10,7 @@ input:
                     other {# bokningar}
                 }
             h2: Aktuella kampanjer
-            respondButton: 'Anmäl till { campaign }'
+            respondButton: 'Anmäl'
             responses: |-
                 {numResponses, plural,
                     =0 {inga anmälningar}
@@ -20,7 +20,7 @@ input:
             status: '{target} har'
         surveys:
             h2: Enkäter
-            respondButton: 'Svara på { survey }'
+            respondButton: 'Svara'
     summaryLabel: Sammanfattning
     summaryLink: Sammanfattning
 instructions:

--- a/src/components/panes/InputPane.jsx
+++ b/src/components/panes/InputPane.jsx
@@ -146,7 +146,9 @@ export default class InputPane extends PaneBase {
                 if (listItems) {
                     surveyContent = (
                         <ul className="InputPane-summaryList">
-                        { listItems.toList().map(survey => {
+                        { listItems.toList().sort(
+                            (s0, s1) => s0.get('title').localeCompare(s1.get('title'))
+                        ).map(survey => {
                             let id = survey.get('id');
 
                             let active = (this.props.step === "call")


### PR DESCRIPTION
This PR changes how surveys are listed during a call, so that they're sorted alphabetically. It also changes the label of the buttons to navigate to a survey (or campaign) to not include the name, which was causing overlaps when names are long.

Fixes #256 