### PR TITLE
Token refresh via heartbeat

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
     "cookie-parser": "^1.4.3",
     "del": "^1.1.1",
     "express": "^4.14.0",
-    "express-zetkin-auth": "~1.2.1",
+    "express-zetkin-auth": "~2.1.0",
     "flat": "^2.0.1",
     "gulp": "^3.9.0",
     "gulp-babel": "^6.1.2",
@@ -66,7 +66,7 @@
     "run-sequence": "^1.2.2",
     "sugar-date": "^2.0.0",
     "webpack": "^2.2.1",
-    "zetkin": "~1.3.1"
+    "zetkin": "~1.4.0"
   },
   "devDependencies": {
     "concurrently": "^3.1.0",

--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
     "gulp-concat": "^2.6.0",
     "gulp-imagemin": "^1.0.1",
     "gulp-newer": "^0.5.1",
-    "gulp-sass": "^2.0.4",
+    "gulp-sass": "^3.0.0",
     "gulp-shell": "^0.4.3",
     "gulp-streamify": "0.0.5",
     "gulp-uglify": "^2.0.0",

--- a/src/client/main.js
+++ b/src/client/main.js
@@ -22,6 +22,23 @@ import routes from '../components/routes';
 
 const USE_TLS = (process.env.ZETKIN_USE_TLS == '1');
 
+let pendingHeartbeat = null;
+const heartbeat = () => {
+    if (!pendingHeartbeat) {
+        pendingHeartbeat = fetch('/api/heartbeat');
+        pendingHeartbeat
+            .then(() => {
+                pendingHeartbeat = null;
+                const token = cookie.get('apiAccessToken');
+                if (token) {
+                    Z.setAccessToken(token);
+                }
+            })
+            .catch(() => {
+                pendingHeartbeat = null;
+            });
+    }
+}
 
 window.onload = function() {
     Z.configure({
@@ -41,6 +58,8 @@ window.onload = function() {
     if (token) {
         Z.setAccessToken(token);
     }
+
+    setInterval(heartbeat, 60000);
 
     let stateElem = document.getElementById('App-initialState');
     let stateJson = stateElem.innerText || stateElem.textContent;

--- a/src/server/app.js
+++ b/src/server/app.js
@@ -77,6 +77,8 @@ export default function initApp(messages) {
     app.use(auth.initialize(authOpts));
     app.get('/logout', auth.logout(authOpts));
 
+    app.get('/api/heartbeat', auth.heartbeat(authOpts));
+
     // Redirect to assignments page if logged in
     app.get('/', auth.validate(authOpts, true), (req, res, next) => {
         if (req.isZetkinAuthenticated) {


### PR DESCRIPTION
This PR implements a heartbeat (using recent additions to `express-zetkin-auth` and `zetkin.js`) to refresh tokens as they are getting _close_ to expiring.

Fixes #250