### PR TITLE
Enable keyboard navigation with the tab key

### DIFF
--- a/src/components/App.jsx
+++ b/src/components/App.jsx
@@ -13,15 +13,6 @@ export default class App extends React.Component {
         if (activeCalls.size > 0) {
             this.props.dispatch(showOverlay('resume'));
         }
-
-        // TODO: This is not a great solution to the issue where panes open
-        // just because of tabbing (#104) but it works. Might be a pain once
-        // surveys are in Call and user wants to tab between inputs.
-        window.addEventListener('keydown', ev => {
-            if (ev.keyCode == 9) {
-                ev.preventDefault();
-            }
-        });
     }
 
     render() {

--- a/src/components/panes/PaneBase.jsx
+++ b/src/components/panes/PaneBase.jsx
@@ -46,13 +46,28 @@ export default class PaneBase extends React.Component {
         }
 
         return (
-            <section className={ classes }>
+            <section className={ classes } ref="pane">
                 { header }
                 <div ref="content" className="PaneBase-content">
                     { this.renderContent() }
                 </div>
             </section>
         );
+    }
+
+    // Updates the pane's inert status
+    //
+    // Ideally this would be handled in render() but this old version of React
+    // doesn't recognize it as a valid HTML attribute and thus prevents us from
+    // updating it declaratively. This setter provides an imperative workaround
+    // so that we can make use of the attribute anyway.
+    setInert(inert) {
+        let pane = ReactDOM.findDOMNode(this.refs.pane);
+        if (inert) {
+            pane.setAttribute('inert', '');
+        } else {
+            pane.removeAttribute('inert');
+        }
     }
 
     renderHeader() {

--- a/src/components/panes/ReportPane.jsx
+++ b/src/components/panes/ReportPane.jsx
@@ -71,6 +71,10 @@ export default class ReportPane extends PaneBase {
         );
     }
 
+    componentDidMount() {
+        this.setInert(this.props.step !== 'report')
+    }
+
     componentDidUpdate(prevProps) {
         const report = this.props.report;
         const prevReport = prevProps.report;
@@ -90,6 +94,8 @@ export default class ReportPane extends PaneBase {
                 animatedScrollTo(container, d, 300);
             }
         }
+
+        this.setInert(this.props.step !== 'report')
     }
 
     onBackLinkClick() {


### PR DESCRIPTION
This fixes https://github.com/zetkin/call.zetk.in/issues/263 and https://github.com/zetkin/call.zetk.in/issues/264. The reason for bundling fixes for two issues in one pull request is that one of the fixes is walking back a previous fix and I don't want to reintroduce the original bug, so atomically fixing both in one merge seems better!

| File changed | Issue addressed |
|-|-|
| `App.jsx` | https://github.com/zetkin/call.zetk.in/issues/263 |
| `PaneBase.jsx` | https://github.com/zetkin/call.zetk.in/issues/264 |
| `ReportPane.jsx` | https://github.com/zetkin/call.zetk.in/issues/264 |

So this first fixes https://github.com/zetkin/call.zetk.in/issues/263 by walking back the fix to https://github.com/zetkin/call.zetk.in/issues/104 in `App.jsx`. It then fixes both https://github.com/zetkin/call.zetk.in/issues/264 and https://github.com/zetkin/call.zetk.in/issues/104 simultaneously with the changes to `PaneBase.jsx` and `ReportPane.jsx`.

Comprehensive details are available on the issues themselves so I won't duplicate any of that here. Instead here's a screen recording demonstrating the behaviour of this change to the code. In it, I use the newly re-enabled keyboard navigation to open a call page (https://github.com/zetkin/call.zetk.in/issues/263), then I tab all the way through the UI repeatedly without triggering the unwanted premature focusing of the report pane (https://github.com/zetkin/call.zetk.in/issues/264).

![Screen recording corresponding to the interaction described in the previous paragraph](https://user-images.githubusercontent.com/566159/192113068-90c74dbb-8d9c-417c-8b9b-f6fae0184b80.gif)

Let me know what you think!