### PR TITLE
Render stat item labels as spans instead of paragraphs

### DIFF
--- a/src/components/misc/AssignmentStats.jsx
+++ b/src/components/misc/AssignmentStats.jsx
@@ -32,10 +32,10 @@ const StatsItem = props => {
             <span className="AssignmentStats-itemNumber">
                 { props.number }
             </span>
-            <p className="AssignmentStats-itemLabel">
+            <span className="AssignmentStats-itemLabel">
                 <Msg id={ props.labelMsg }
                     values={{ number: props.number }}/>
-            </p>
+            </span>
         </li>
     );
 };


### PR DESCRIPTION
## Before

https://user-images.githubusercontent.com/566159/195995037-31d03727-a49b-47d1-989c-c69208620482.mp4

## After

https://user-images.githubusercontent.com/566159/195995049-f61ea6c2-58b0-41a6-89c5-f7d9fc35bf41.mp4

Fixes https://github.com/zetkin/call.zetk.in/issues/266