### PR TITLE
Add aria-label to overlay close button

### DIFF
--- a/locale/misc/da.yaml
+++ b/locale/misc/da.yaml
@@ -13,3 +13,4 @@ callLog:
         status22: Samtalen blev afbrudt.
 tagList:
     emptyLabel: Ingen etiketter
+close: Tæt

--- a/locale/misc/en.yaml
+++ b/locale/misc/en.yaml
@@ -23,3 +23,4 @@ callInstructions:
         Tap on the number to call, or enter the number manually on your phone.
         Tapping the number will open your phone app. Return here to your web
         browser to continue using Zetkin and report the call.
+close: Close

--- a/locale/misc/nn.yaml
+++ b/locale/misc/nn.yaml
@@ -20,3 +20,4 @@ tagList:
         } i feltet for personleg info
 callInstructions:
     instructions: "Klikk på nummeret for å ringe eller tast nummeret manuellt på telefonen. Klikkar du på\_nummeret åpnar telefonappen. Gå så tilbake til nettlesaren for å halde fram i Zetkin og logge samtalen."
+close: Lukk

--- a/locale/misc/sv.yaml
+++ b/locale/misc/sv.yaml
@@ -18,3 +18,4 @@ callInstructions:
         Tryck på numret ovan för att ringa, eller knappa in det manuellt i din
         telefon. När du trycker på numret öppnas din telefonapp. Återvänd hit
         till webbläsaren för att fortsätta använda Zetkin.
+close: Stänga

--- a/src/components/overlays/OverlayStack.jsx
+++ b/src/components/overlays/OverlayStack.jsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import CSSTransitionGroup from 'react-addons-css-transition-group';
+import { injectIntl } from 'react-intl';
 import { connect } from 'react-redux';
 
 import { resolveOverlay } from '.';
@@ -11,6 +12,7 @@ const mapStateToProps = state => ({
 });
 
 @connect(mapStateToProps)
+@injectIntl
 export default class OverlayStack extends React.Component {
     render() {
         let content = null;
@@ -27,6 +29,7 @@ export default class OverlayStack extends React.Component {
                 content.push(
                     <button key="closeButton"
                         className="OverlayStack-closeButton"
+                        aria-label={this.props.intl.formatMessage({ id: 'misc.close' })}
                         onClick={ this.onCloseButtonClick.bind(this) }>
                         </button>
                 );


### PR DESCRIPTION
| Before | After |
|-|-|
| <img width="409" alt="VoiceOver announcing button as 'button, group'" src="https://user-images.githubusercontent.com/566159/195999491-831348a0-f94c-4612-8ef8-87ab846b9c08.png"> | <img width="409" alt="VoiceOver announcing button as 'Close, button, group'" src="https://user-images.githubusercontent.com/566159/195999512-d7c1009c-383f-465f-962d-2d5dde6e3b83.png"> |

Fixes https://github.com/zetkin/call.zetk.in/issues/269.