### PR TITLE
Render overlay close button before contents

### DIFF
--- a/src/components/overlays/OverlayStack.jsx
+++ b/src/components/overlays/OverlayStack.jsx
@@ -17,11 +17,7 @@ export default class OverlayStack extends React.Component {
         let overlayData = this.props.overlay;
         if (overlayData) {
             let OverlayComponent = resolveOverlay(overlayData.get('type'));
-            content = [
-                <div key="overlay" className="OverlayStack-overlay">
-                    <OverlayComponent config={ overlayData.get('config') }/>
-                </div>,
-            ];
+            content = [];
 
             if (overlayData.getIn(['config', 'closeButton'], true)) {
                 content.push(
@@ -31,6 +27,12 @@ export default class OverlayStack extends React.Component {
                         </button>
                 );
             }
+
+            content.push(
+                <div key="overlay" className="OverlayStack-overlay">
+                    <OverlayComponent config={ overlayData.get('config') }/>
+                </div>,
+            );
         }
 
         return (


### PR DESCRIPTION
I generated the following screenshots using the [taba11y Chrome extension](https://chrome.google.com/webstore/detail/taba11y/aocppmckdocdjkphmofnklcjhdidgmga?hl=en) to visualize the tab order of the modal dialog.

| Before | After |
|-|-|
| <img width="450" alt="Modal with focus order annotations beginning from an input field halfway down the page" src="https://user-images.githubusercontent.com/566159/195999870-1d19d14e-927d-44e1-a6c3-e88f9d2018d4.png"> | <img width="450" alt="Modal with focus order annotations beginning from the close button at the top" src="https://user-images.githubusercontent.com/566159/195999905-7142551e-57ed-4d46-8dba-6ce87c44726c.png"> |

Fixes https://github.com/zetkin/call.zetk.in/issues/270.