### PR TITLE
Align header nav DOM order with visual order

### DIFF
--- a/src/components/header/Header.jsx
+++ b/src/components/header/Header.jsx
@@ -31,11 +31,11 @@ export default class Header extends React.Component {
                 <Logo/>
                 <div className="Header-currentApp">Zetkin Call</div>
                 <div className="Header-nav">
-                    { userWidget }
                     <FormattedLink className="Header-navLink"
                         msgId="header.dashboardLink"
                         href={ dashboardUrl }
                         />
+                    { userWidget }
                 </div>
             </header>
         );

--- a/src/components/header/Header.scss
+++ b/src/components/header/Header.scss
@@ -44,13 +44,14 @@
 
     .Header-nav {
         flex: 4;
+        display: flex;
+        justify-content: flex-end;
 
         @include small-screen {
             flex: 2;
         }
 
         .Header-navLink {
-            float: right;
             margin: 0.5em;
             @include icon-button($fa-var-home);
         }


### PR DESCRIPTION
## Before

Here's a screenshot using [taba11y](https://chrome.google.com/webstore/detail/taba11y/aocppmckdocdjkphmofnklcjhdidgmga) to visualize the focus order of the header nav. The `My Page` link is annotated with a higher index than the `Joe Caller` user dropdown menu despite being before it visually.

<img width="775" alt="Header nav with annotations as described above" src="https://user-images.githubusercontent.com/566159/196000912-22289c5f-3f89-4ec3-bb6a-fab8ec9242d0.png">

## After

The annotated tab indices from taba11y now run `0` `1` `2` as the focus order matches the visual order.

<img width="775" alt="Header nav with annotations as described above" src="https://user-images.githubusercontent.com/566159/196000936-d31b4eaa-f333-4154-a2e2-9ab01a31d7c5.png">

Fixes https://github.com/zetkin/call.zetk.in/issues/278.