### PR TITLE
Use <button> element for tutorial close button

### DIFF
--- a/src/components/tutorial/TutorialNote.jsx
+++ b/src/components/tutorial/TutorialNote.jsx
@@ -44,10 +44,12 @@ export default class TutorialNote extends React.Component {
                 <Msg tagName="h2" id={ messages.get('header') }/>
                 <Msg tagName="p" id={ messages.get('text') }/>
                 { manualButton }
-                <FormattedLink msgId="tutorial.closeButton"
-                    className="TutorialNote-closeLink"
-                    onClick={ this.onCloseClick.bind(this) }
-                    />
+                <button className="TutorialNote-closeButton"
+                    onClick={ this.onCloseClick.bind(this) }>
+                    {this.props.intl.formatMessage({
+                        id: 'tutorial.closeButton'
+                    })}
+                </button>
             </div>
         );
     }

--- a/src/components/tutorial/TutorialNote.scss
+++ b/src/components/tutorial/TutorialNote.scss
@@ -27,8 +27,9 @@
         font-size: 0.9em;
     }
 
-    .TutorialNote-closeLink, .TutorialNote-manualLink {
+    .TutorialNote-closeButton, .TutorialNote-manualLink {
         display: block;
+        background: transparent;
         padding: 0.5em 1em;
         margin: 0.5em 0 0;
         border: 1px solid white;
@@ -46,7 +47,7 @@
     }
 
     @include medium-screen {
-        .TutorialNote-closeLink, .TutorialNote-manualLink {
+        .TutorialNote-closeButton, .TutorialNote-manualLink {
             float: right;
             border-width: 0;
             font-size: 0.8em;


### PR DESCRIPTION
| Before | After |
|-|-|
| <img width="443" alt="VoiceOver annotation saying 'link, I understand' with the close button focused" src="https://user-images.githubusercontent.com/566159/196054671-9423fd02-44ea-4cd9-83aa-d35cf42ccd8a.png"> | <img width="443" alt="VoiceOver annotation saying 'I understand, button' with the close button focused" src="https://user-images.githubusercontent.com/566159/196054672-1fd38c8d-2e8f-455e-9ca5-13458dcd0d95.png"> |

Fixes https://github.com/zetkin/call.zetk.in/issues/274.

