### PR TITLE
Show call assignments with no end date

### DIFF
--- a/src/actions/assignment.js
+++ b/src/actions/assignment.js
@@ -3,10 +3,8 @@ import * as types from '.';
 
 export function retrieveUserAssignments() {
     return ({ dispatch, z }) => {
-        let today = (new Date()).format('{yyyy}{MM}{dd}')
         let filters = [
-            ['start_date', '<=', today],
-            ['end_date', '>=', today],
+            ['active', '==', 1],
         ];
 
         dispatch({


### PR DESCRIPTION
Resolves #286 

* Changes the fetch of call assignments to use the new `active` filter instead of `start_date` and `end_date`.

![bild](https://github.com/zetkin/call.zetk.in/assets/14962107/85743af2-66d7-4638-a82b-a9f097df8f2a)

Requires zetkin/zetkin-platform#615