### PR TITLE
Add default null value to select box

### DIFF
--- a/locale/surveyForm/da.yaml
+++ b/locale/surveyForm/da.yaml
@@ -1,2 +1,2 @@
 select:
-    default: Vælge et alternativ
+    default: Vælg et alternativ

--- a/locale/surveyForm/da.yaml
+++ b/locale/surveyForm/da.yaml
@@ -1,0 +1,2 @@
+select:
+    default: Vælge et alternativ

--- a/locale/surveyForm/en.yaml
+++ b/locale/surveyForm/en.yaml
@@ -1,0 +1,2 @@
+select:
+    default: Select an option

--- a/locale/surveyForm/nn.yaml
+++ b/locale/surveyForm/nn.yaml
@@ -1,0 +1,2 @@
+select:
+    default: Velge et alternativ

--- a/locale/surveyForm/nn.yaml
+++ b/locale/surveyForm/nn.yaml
@@ -1,2 +1,2 @@
 select:
-    default: Velge et alternativ
+    default: Velg et alternativ

--- a/locale/surveyForm/sv.yaml
+++ b/locale/surveyForm/sv.yaml
@@ -1,0 +1,2 @@
+select:
+    default: Välj ett alternativ

--- a/src/store/surveys.js
+++ b/src/store/surveys.js
@@ -127,9 +127,16 @@ export default createReducer(initialState, {
             }
         });
 
-        return state
-            .updateIn(['pendingResponsesByCall', callId, surveyId], survey => survey?
-                survey.mergeDeep(surveyData) : surveyData);
+        const surveyPath = ['pendingResponsesByCall', callId, surveyId];
+        const responsePath = surveyPath.concat(['responses', elemId.toString()])
+        if (state.getIn(responsePath) != null) {
+          return state
+              .updateIn(responsePath, resp => immutable.fromJS(response));
+        } else {
+          return state
+              .updateIn(surveyPath, survey => survey?
+                  survey.mergeDeep(surveyData) : surveyData);
+        }
     },
 
     [types.TOGGLE_SURVEY_INCLUDED]: (state, action) => {


### PR DESCRIPTION
Adds a default option for surveys select box, "Select an option" which results in the value being `[]`.

![bild](https://github.com/zetkin/call.zetk.in/assets/14962107/8a006728-43af-4cdc-b9aa-c6961b8ae77c)


This also solves a previously unkown (?) bug which can be reproduced like this:
1. Create a survey with an option type question (regardless of which one)
2. Make a call and enter the survey
3. Play around with the options, i.e. "change your mind"
4. Submit

Expected results: Only the latest set of options should be part of the response
Actual results: All the options that were selected at one time are part of the response.

Requires zetkin/zetkin-common#59