### PR TITLE
Move JS build from Docker build to first run

### DIFF
--- a/env/app/Dockerfile
+++ b/env/app/Dockerfile
@@ -35,7 +35,6 @@ RUN npm install
 ## Install the app itself
 
 COPY . ./
-RUN npm install --unsafe-perm
 
 # Init
 

--- a/env/app/run.sh
+++ b/env/app/run.sh
@@ -4,7 +4,7 @@ cd /var/app
 
 if [ "$NODE_ENV" == "production" ]
 then
-    #./node_modules/.bin/webpack
+    npm install --unsafe-perm
     node build/app/server/main
 else
     ./node_modules/.bin/concurrently \


### PR DESCRIPTION
This PR moves the building of frontend code to runtime, instead of the docker build. This is so that a single image built from the code in this repo can be used in multiple environments.